### PR TITLE
Adding simplex integration

### DIFF
--- a/modules/data_l1/src/main/scala/org/proof_of_attendance_metagraph/data_l1/daemons/DaemonApis.scala
+++ b/modules/data_l1/src/main/scala/org/proof_of_attendance_metagraph/data_l1/daemons/DaemonApis.scala
@@ -72,7 +72,7 @@ object DaemonApis {
       config: ApplicationConfig,
       signer: Signer[F]
     ): F[Unit] = {
-      val simplexFetcher = SimplexFetcher.make[F](config.simplexDaemon)
+      val simplexFetcher = SimplexFetcher.make[F](config)
       val simplexProcessor = Processor.make[F](simplexFetcher, signer)
       logger.info("Spawning Simplex daemon") >>
         spawn(

--- a/modules/data_l1/src/main/scala/org/proof_of_attendance_metagraph/data_l1/daemons/fetcher/SimplexFetcher.scala
+++ b/modules/data_l1/src/main/scala/org/proof_of_attendance_metagraph/data_l1/daemons/fetcher/SimplexFetcher.scala
@@ -1,26 +1,68 @@
 package org.proof_of_attendance_metagraph.data_l1.daemons.fetcher
 
-import cats.effect.Async
-import cats.syntax.applicative._
+import cats.effect.{Async, Resource}
+import cats.syntax.applicativeError._
 import cats.syntax.flatMap._
-import eu.timepit.refined.auto._
-import org.proof_of_attendance_metagraph.shared_data.app.ApplicationConfig.SimplexDaemonConfig
+import cats.syntax.functor._
+import fs2.io.net.Network
+import io.circe.generic.auto._
+import org.http4s._
+import org.http4s.circe._
+import org.http4s.client.Client
+import org.proof_of_attendance_metagraph.shared_data.app.ApplicationConfig
 import org.proof_of_attendance_metagraph.shared_data.types.DataUpdates.{ProofOfAttendanceUpdate, SimplexUpdate}
-import org.tessellation.schema.address.Address
+import org.proof_of_attendance_metagraph.shared_data.types.SimplexTypes.{SimplexApiResponse, SimplexEvent}
+import org.tessellation.node.shared.resources.MkHttpClient
+import org.typelevel.ci.CIString
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
 object SimplexFetcher {
 
-  def make[F[_] : Async](simplexDaemonConfig: SimplexDaemonConfig): Fetcher[F] =
+  def make[F[_] : Async : Network](applicationConfig: ApplicationConfig): Fetcher[F] =
     new Fetcher[F] {
       private val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromClass(SimplexFetcher.getClass)
 
-      override def getAddressesAndBuildUpdates: F[List[ProofOfAttendanceUpdate]] =
-        logger.info("Fetching from SimplexFetcher") >>
-          List[ProofOfAttendanceUpdate](
-            SimplexUpdate(Address("DAG0KpQNqMsED4FC5grhFCBWG8iwU8Gm6aLhB9w5"))
-          ).pure
+      def fetchTransactions(url: String): F[SimplexApiResponse] = {
+        val simplexConfig = applicationConfig.simplexDaemon
+        val authorizationHeader = CIString("Authorization")
 
+        val clientResource: Resource[F, Client[F]] = MkHttpClient.forAsync[F].newEmber(applicationConfig.http4s.client)
+
+        clientResource.use { client =>
+          val request = Request[F](
+            method = Method.GET,
+            uri = Uri.unsafeFromString(url)
+          ).withHeaders(Header.Raw(authorizationHeader, s"ApiKey ${simplexConfig.apiKey.get}"))
+
+          client.expect[SimplexApiResponse](request)(jsonOf[F, SimplexApiResponse])
+        }
+      }
+
+      override def getAddressesAndBuildUpdates: F[List[ProofOfAttendanceUpdate]] = {
+        val simplexConfig = applicationConfig.simplexDaemon
+        val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+        val currentDate: String = LocalDate.now().format(dateFormatter)
+        val url = s"${simplexConfig.apiUrl.get}/proof-of-attendance-metagraph/simplex-events?eventDate=${currentDate}"
+
+        for {
+          _ <- logger.info(s"Fetching from Simplex using URL: $url")
+          simplexApiResponse <- fetchTransactions(url).handleErrorWith { err =>
+            logger.error(s"Error when fetching from Lattice Simplex API: ${err.getMessage}")
+              .as(SimplexApiResponse(List.empty[SimplexEvent]))
+          }
+          _ <- logger.info(s"Found ${simplexApiResponse.data.length} DAG transactions")
+          eventsGroupedByAddress = simplexApiResponse.data.groupBy(event => event.destinationWalletAddress)
+          dataUpdates = eventsGroupedByAddress.foldLeft(List.empty[ProofOfAttendanceUpdate]) { (acc, transaction) =>
+            val (address, events) = transaction
+            acc :+ SimplexUpdate(address, events.toSet)
+          }
+
+          _ <- logger.info(s"Simplex Updates: $dataUpdates")
+        } yield dataUpdates
+      }
     }
 }

--- a/modules/shared_data/src/main/resources/application.conf
+++ b/modules/shared_data/src/main/resources/application.conf
@@ -14,7 +14,7 @@ exolix-daemon {
 simplex-daemon {
   api-url = ""
   api-key = "api_key"
-  idle-time = 30 seconds
+  idle-time = 1 hour
 }
 
 twitter-daemon {

--- a/modules/shared_data/src/main/scala/org/proof_of_attendance_metagraph/shared_data/LifecycleSharedFunctions.scala
+++ b/modules/shared_data/src/main/scala/org/proof_of_attendance_metagraph/shared_data/LifecycleSharedFunctions.scala
@@ -33,11 +33,13 @@ object LifecycleSharedFunctions {
                 val message = "Could not get the epochProgress from currency snapshot. lastCurrencySnapshot not found"
                 logger.error(message) >> new Exception(message).raiseError[F, EpochProgress]
             }
-          } yield combineProofOfAttendance(
-            acc,
-            epochProgress,
-            signedUpdate
-          )
+
+            updatedState <- combineProofOfAttendance(
+              acc,
+              epochProgress,
+              signedUpdate
+            )
+          } yield updatedState
         }
     }
   }

--- a/modules/shared_data/src/main/scala/org/proof_of_attendance_metagraph/shared_data/combiners/ExolixCombiner.scala
+++ b/modules/shared_data/src/main/scala/org/proof_of_attendance_metagraph/shared_data/combiners/ExolixCombiner.scala
@@ -1,0 +1,89 @@
+package org.proof_of_attendance_metagraph.shared_data.combiners
+
+import cats.effect.Async
+import cats.syntax.applicative._
+import cats.syntax.functor._
+import org.proof_of_attendance_metagraph.shared_data.Utils.toTokenAmountFormat
+import org.proof_of_attendance_metagraph.shared_data.types.DataUpdates._
+import org.proof_of_attendance_metagraph.shared_data.types.ExolixTypes.ExolixTransaction
+import org.proof_of_attendance_metagraph.shared_data.types.States._
+import org.tessellation.schema.address.Address
+import org.tessellation.schema.epoch.EpochProgress
+import org.typelevel.log4cats.SelfAwareStructuredLogger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+object ExolixCombiner {
+  private val exolix_reward_amount: Long = 35L
+
+  private def updateExolixDataSourceState[F[_] : Async](
+    existing            : ExolixDataSource,
+    exolixUpdate        : ExolixUpdate,
+    currentEpochProgress: EpochProgress,
+    currentDataSources  : Set[DataSources],
+    logger              : SelfAwareStructuredLogger[F]
+  ): F[Set[DataSources]] = {
+    val existingTxnsIds = existing.latestTransactions.map(_.id) ++ existing.olderTransactions.map(_.id)
+    val newTxns = exolixUpdate.exolixTransactions.filter(txn => !existingTxnsIds.contains(txn.id))
+
+    if (newTxns.isEmpty) {
+      currentDataSources.pure[F]
+    } else {
+      // This scenario is when we receive new transactions before pay the rewards
+      val rewardsAmount = if (currentEpochProgress.value.value < existing.epochProgressToReward.value.value) {
+        (exolix_reward_amount * newTxns.size) + existing.amountToReward
+      } else {
+        exolix_reward_amount * newTxns.size
+      }
+
+      val updatedExolixDataSource = ExolixDataSource(
+        currentEpochProgress,
+        toTokenAmountFormat(rewardsAmount),
+        newTxns,
+        existing.latestTransactions ++ existing.olderTransactions
+      )
+
+      logger.info(s"Updated ExolixDataSource for address ${exolixUpdate.address}").as(
+        currentDataSources - existing + updatedExolixDataSource
+      )
+    }
+  }
+
+  def updateStateExolixResponse[F[_] : Async](
+    currentCalculatedState: Map[Address, Set[DataSources]],
+    currentEpochProgress  : EpochProgress,
+    exolixUpdate          : ExolixUpdate
+  ): F[Map[Address, Set[DataSources]]] = {
+    def logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromName[F]("ExolixCombiner")
+
+    val newExolixDataSource = ExolixDataSource(
+      currentEpochProgress,
+      toTokenAmountFormat(exolix_reward_amount * exolixUpdate.exolixTransactions.size),
+      exolixUpdate.exolixTransactions,
+      Set.empty[ExolixTransaction]
+    )
+
+    val updatedDataSourcesF: F[Set[DataSources]] = currentCalculatedState.get(exolixUpdate.address) match {
+      case None =>
+        logger.info(s"Could not find any DataSource to the address ${exolixUpdate.address}, creating a new one").as(
+          Set[DataSources](newExolixDataSource)
+        )
+      case Some(dataSources) =>
+        dataSources.collectFirst {
+          case ex: ExolixDataSource => ex
+        }.fold(
+          logger.info(s"Could not find ExolixDataSource to address ${exolixUpdate.address}, creating a new one").as(
+            dataSources + newExolixDataSource
+          )
+        ) { existing =>
+          updateExolixDataSourceState(
+            existing,
+            exolixUpdate,
+            currentEpochProgress,
+            dataSources,
+            logger
+          )
+        }
+    }
+    updatedDataSourcesF.map(updatedDataSources => currentCalculatedState + (exolixUpdate.address -> updatedDataSources))
+  }
+}

--- a/modules/shared_data/src/main/scala/org/proof_of_attendance_metagraph/shared_data/combiners/IntegrationnetOperatorsCombiner.scala
+++ b/modules/shared_data/src/main/scala/org/proof_of_attendance_metagraph/shared_data/combiners/IntegrationnetOperatorsCombiner.scala
@@ -1,0 +1,39 @@
+package org.proof_of_attendance_metagraph.shared_data.combiners
+
+import cats.effect.Async
+import org.proof_of_attendance_metagraph.shared_data.combiners.ProofOfAttendanceCombiner.epoch_progress_1_day
+import org.proof_of_attendance_metagraph.shared_data.types.DataUpdates._
+import org.proof_of_attendance_metagraph.shared_data.types.States._
+import org.tessellation.schema.address.Address
+import org.tessellation.schema.epoch.EpochProgress
+
+//TODO: Implement the correct flow
+object IntegrationnetOperatorsCombiner {
+  def updateStateIntegrationnetOperatorsResponse[F[_] : Async](
+    currentCalculatedState          : Map[Address, Set[DataSources]],
+    currentEpochProgress            : EpochProgress,
+    integrationnetNodeOperatorUpdate: IntegrationnetNodeOperatorUpdate
+  ): F[Map[Address, Set[DataSources]]] = Async[F].delay {
+    val integrationnetNodeOperatorDataSource = IntegrationnetNodeOperatorLineDataSource(
+      currentEpochProgress,
+      400, // TBD
+      integrationnetNodeOperatorUpdate.address.value.value
+    )
+    val integrationnetNodeOperatorDataSourceList = Set[DataSources](integrationnetNodeOperatorDataSource)
+    val updatedDataSources = currentCalculatedState
+      .get(integrationnetNodeOperatorUpdate.address)
+      .fold(integrationnetNodeOperatorDataSourceList) { dataSources =>
+        dataSources.collectFirst {
+            case ex: IntegrationnetNodeOperatorLineDataSource => ex
+          }
+          .fold(dataSources + integrationnetNodeOperatorDataSource) { existing =>
+            if (existing.epochProgressToReward.value.value + epoch_progress_1_day < currentEpochProgress.value.value) {
+              dataSources - existing + integrationnetNodeOperatorDataSource
+            } else {
+              dataSources
+            }
+          }
+      }
+    currentCalculatedState + (integrationnetNodeOperatorUpdate.address -> updatedDataSources)
+  }
+}

--- a/modules/shared_data/src/main/scala/org/proof_of_attendance_metagraph/shared_data/combiners/ProofOfAttendanceCombiner.scala
+++ b/modules/shared_data/src/main/scala/org/proof_of_attendance_metagraph/shared_data/combiners/ProofOfAttendanceCombiner.scala
@@ -1,136 +1,27 @@
 package org.proof_of_attendance_metagraph.shared_data.combiners
 
-import org.proof_of_attendance_metagraph.shared_data.Utils.toTokenAmountFormat
+import cats.effect.Async
+import cats.syntax.functor._
+import org.proof_of_attendance_metagraph.shared_data.combiners.ExolixCombiner.updateStateExolixResponse
+import org.proof_of_attendance_metagraph.shared_data.combiners.IntegrationnetOperatorsCombiner.updateStateIntegrationnetOperatorsResponse
+import org.proof_of_attendance_metagraph.shared_data.combiners.SimplexCombiner.updateStateSimplexResponse
+import org.proof_of_attendance_metagraph.shared_data.combiners.TwitterCombiner.updateStateTwitterResponse
 import org.proof_of_attendance_metagraph.shared_data.types.DataUpdates._
 import org.proof_of_attendance_metagraph.shared_data.types.States._
 import org.tessellation.currency.dataApplication.DataState
 import org.tessellation.ext.cats.syntax.next.catsSyntaxNext
-import org.tessellation.schema.address.Address
 import org.tessellation.schema.epoch.EpochProgress
 import org.tessellation.security.signature.Signed
 
 object ProofOfAttendanceCombiner {
-  private val epoch_progress_1_day: Long = 1440L
-  private val exolix_reward_amount: Long = 35L
+  val epoch_progress_1_day: Long = 1440L
 
-  private def updateStateExolixResponse(
-    currentCalculatedState: Map[Address, Set[DataSources]],
-    epochProgressToReward : EpochProgress,
-    exolixUpdate          : ExolixUpdate
-  ): Map[Address, Set[DataSources]] = {
-    val exolixDataSource = ExolixDataSource(
-      epochProgressToReward,
-      toTokenAmountFormat(exolix_reward_amount),
-      exolixUpdate.exolixTransaction
-    )
-    val exolixDataSourceList = Set[DataSources](exolixDataSource)
-    val updatedDataSources = currentCalculatedState
-      .get(exolixUpdate.address)
-      .fold(exolixDataSourceList) { dataSources =>
-        dataSources.collectFirst {
-            case ex: ExolixDataSource => ex
-          }
-          .fold(dataSources + exolixDataSource) { existing =>
-            if (existing.epochProgressToReward.value.value + epoch_progress_1_day < epochProgressToReward.value.value) {
-              dataSources - existing + exolixDataSource
-            } else {
-              dataSources
-            }
-          }
-      }
-    currentCalculatedState + (exolixUpdate.address -> updatedDataSources)
-  }
-
-  private def updateStateSimplexResponse(
-    currentCalculatedState: Map[Address, Set[DataSources]],
-    epochProgressToReward : EpochProgress,
-    simplexUpdate         : SimplexUpdate
-  ): Map[Address, Set[DataSources]] = {
-    val simplexDataSource = SimplexDataSource(
-      epochProgressToReward,
-      200, // TBD
-      simplexUpdate.address.value.value
-    )
-    val simplexDataSourceList = Set[DataSources](simplexDataSource)
-    val updatedDataSources = currentCalculatedState
-      .get(simplexUpdate.address)
-      .fold(simplexDataSourceList) { dataSources =>
-        dataSources.collectFirst {
-            case ex: SimplexDataSource => ex
-          }
-          .fold(dataSources + simplexDataSource) { existing =>
-            if (existing.epochProgressToReward.value.value + epoch_progress_1_day < epochProgressToReward.value.value) {
-              dataSources - existing + simplexDataSource
-            } else {
-              dataSources
-            }
-          }
-      }
-    currentCalculatedState + (simplexUpdate.address -> updatedDataSources)
-  }
-
-  private def updateTwitterResponse(
-    currentCalculatedState: Map[Address, Set[DataSources]],
-    epochProgressToReward : EpochProgress,
-    twitterUpdate         : TwitterUpdate
-  ): Map[Address, Set[DataSources]] = {
-    val twitterDataSource = TwitterDataSource(
-      epochProgressToReward,
-      300, // TBD
-      twitterUpdate.address.value.value
-    )
-    val twitterDataSourceList = Set[DataSources](twitterDataSource)
-    val updatedDataSources = currentCalculatedState
-      .get(twitterUpdate.address)
-      .fold(twitterDataSourceList) { dataSources =>
-        dataSources.collectFirst {
-            case ex: TwitterDataSource => ex
-          }
-          .fold(dataSources + twitterDataSource) { existing =>
-            if (existing.epochProgressToReward.value.value + epoch_progress_1_day < epochProgressToReward.value.value) {
-              dataSources - existing + twitterDataSource
-            } else {
-              dataSources
-            }
-          }
-      }
-    currentCalculatedState + (twitterUpdate.address -> updatedDataSources)
-  }
-
-  private def updateIntegrationnetOperatorsResponse(
-    currentCalculatedState          : Map[Address, Set[DataSources]],
-    epochProgressToReward           : EpochProgress,
-    integrationnetNodeOperatorUpdate: IntegrationnetNodeOperatorUpdate
-  ): Map[Address, Set[DataSources]] = {
-    val integrationnetNodeOperatorDataSource = IntegrationnetNodeOperatorLineDataSource(
-      epochProgressToReward,
-      400, // TBD
-      integrationnetNodeOperatorUpdate.address.value.value
-    )
-    val integrationnetNodeOperatorDataSourceList = Set[DataSources](integrationnetNodeOperatorDataSource)
-    val updatedDataSources = currentCalculatedState
-      .get(integrationnetNodeOperatorUpdate.address)
-      .fold(integrationnetNodeOperatorDataSourceList) { dataSources =>
-        dataSources.collectFirst {
-            case ex: IntegrationnetNodeOperatorLineDataSource => ex
-          }
-          .fold(dataSources + integrationnetNodeOperatorDataSource) { existing =>
-            if (existing.epochProgressToReward.value.value + epoch_progress_1_day < epochProgressToReward.value.value) {
-              dataSources - existing + integrationnetNodeOperatorDataSource
-            } else {
-              dataSources
-            }
-          }
-      }
-    currentCalculatedState + (integrationnetNodeOperatorUpdate.address -> updatedDataSources)
-  }
-
-  def combineProofOfAttendance(
+  def combineProofOfAttendance[F[_] : Async](
     oldState            : DataState[ProofOfAttendanceOnChainState, ProofOfAttendanceCalculatedState],
     currentEpochProgress: EpochProgress,
     update              : Signed[ProofOfAttendanceUpdate]
-  ): DataState[ProofOfAttendanceOnChainState, ProofOfAttendanceCalculatedState] = {
-    val updatedCalculatedState = update.value match {
+  ): F[DataState[ProofOfAttendanceOnChainState, ProofOfAttendanceCalculatedState]] = {
+    val updatedCalculatedStateF = update.value match {
       case update: ExolixUpdate =>
         updateStateExolixResponse(
           oldState.calculated.addresses,
@@ -144,13 +35,13 @@ object ProofOfAttendanceCombiner {
           update
         )
       case update: TwitterUpdate =>
-        updateTwitterResponse(
+        updateStateTwitterResponse(
           oldState.calculated.addresses,
           currentEpochProgress.next,
           update
         )
       case update: IntegrationnetNodeOperatorUpdate =>
-        updateIntegrationnetOperatorsResponse(
+        updateStateIntegrationnetOperatorsResponse(
           oldState.calculated.addresses,
           currentEpochProgress.next,
           update
@@ -158,9 +49,10 @@ object ProofOfAttendanceCombiner {
     }
 
     val updates: List[ProofOfAttendanceUpdate] = update.value :: oldState.onChain.updates
-    DataState(
+
+    updatedCalculatedStateF.map(updatedCalculatedState => DataState(
       ProofOfAttendanceOnChainState(updates),
       ProofOfAttendanceCalculatedState(updatedCalculatedState)
-    )
+    ))
   }
 }

--- a/modules/shared_data/src/main/scala/org/proof_of_attendance_metagraph/shared_data/combiners/SimplexCombiner.scala
+++ b/modules/shared_data/src/main/scala/org/proof_of_attendance_metagraph/shared_data/combiners/SimplexCombiner.scala
@@ -1,0 +1,89 @@
+package org.proof_of_attendance_metagraph.shared_data.combiners
+
+import cats.effect.Async
+import cats.syntax.applicative._
+import cats.syntax.functor._
+import org.proof_of_attendance_metagraph.shared_data.Utils.toTokenAmountFormat
+import org.proof_of_attendance_metagraph.shared_data.types.DataUpdates._
+import org.proof_of_attendance_metagraph.shared_data.types.SimplexTypes.SimplexEvent
+import org.proof_of_attendance_metagraph.shared_data.types.States._
+import org.tessellation.schema.address.Address
+import org.tessellation.schema.epoch.EpochProgress
+import org.typelevel.log4cats.SelfAwareStructuredLogger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+object SimplexCombiner {
+  private val simplex_reward_amount: Long = 35L
+
+  private def updateSimplexDataSourceState[F[_] : Async](
+    existing            : SimplexDataSource,
+    simplexUpdate       : SimplexUpdate,
+    currentEpochProgress: EpochProgress,
+    currentDataSources  : Set[DataSources],
+    logger              : SelfAwareStructuredLogger[F]
+  ): F[Set[DataSources]] = {
+    val existingTxnsIds = existing.latestEvents.map(_.eventId) ++ existing.olderEvents.map(_.eventId)
+    val newTxns = simplexUpdate.simplexEvents.filter(txn => !existingTxnsIds.contains(txn.eventId))
+
+    if (newTxns.isEmpty) {
+      currentDataSources.pure[F]
+    } else {
+      // This scenario is when we receive new transactions before pay the rewards
+      val rewardsAmount = if (currentEpochProgress.value.value < existing.epochProgressToReward.value.value) {
+        (simplex_reward_amount * newTxns.size) + existing.amountToReward
+      } else {
+        simplex_reward_amount * newTxns.size
+      }
+
+      val updatedSimplexDataSource = SimplexDataSource(
+        currentEpochProgress,
+        toTokenAmountFormat(rewardsAmount),
+        newTxns,
+        existing.latestEvents ++ existing.olderEvents
+      )
+
+      logger.info(s"Updated SimplexDataSource for address ${simplexUpdate.address}").as(
+        currentDataSources - existing + updatedSimplexDataSource
+      )
+    }
+  }
+
+  def updateStateSimplexResponse[F[_] : Async](
+    currentCalculatedState: Map[Address, Set[DataSources]],
+    currentEpochProgress  : EpochProgress,
+    simplexUpdate         : SimplexUpdate
+  ): F[Map[Address, Set[DataSources]]] = {
+    def logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromName[F]("SimplexCombiner")
+
+    val newSimplexDataSource = SimplexDataSource(
+      currentEpochProgress,
+      toTokenAmountFormat(simplex_reward_amount * simplexUpdate.simplexEvents.size),
+      simplexUpdate.simplexEvents,
+      Set.empty[SimplexEvent]
+    )
+
+    val updatedDataSourcesF: F[Set[DataSources]] = currentCalculatedState.get(simplexUpdate.address) match {
+      case None =>
+        logger.info(s"Could not find any DataSource to the address ${simplexUpdate.address}, creating a new one").as(
+          Set[DataSources](newSimplexDataSource)
+        )
+      case Some(dataSources) =>
+        dataSources.collectFirst {
+          case ex: SimplexDataSource => ex
+        }.fold(
+          logger.info(s"Could not find SimplexDataSource to address ${simplexUpdate.address}, creating a new one").as(
+            dataSources + newSimplexDataSource
+          )
+        ) { existing =>
+          updateSimplexDataSourceState(
+            existing,
+            simplexUpdate,
+            currentEpochProgress,
+            dataSources,
+            logger
+          )
+        }
+    }
+    updatedDataSourcesF.map(updatedDataSources => currentCalculatedState + (simplexUpdate.address -> updatedDataSources))
+  }
+}

--- a/modules/shared_data/src/main/scala/org/proof_of_attendance_metagraph/shared_data/combiners/TwitterCombiner.scala
+++ b/modules/shared_data/src/main/scala/org/proof_of_attendance_metagraph/shared_data/combiners/TwitterCombiner.scala
@@ -1,0 +1,41 @@
+package org.proof_of_attendance_metagraph.shared_data.combiners
+
+import cats.effect.Async
+import org.proof_of_attendance_metagraph.shared_data.combiners.ProofOfAttendanceCombiner.epoch_progress_1_day
+import org.proof_of_attendance_metagraph.shared_data.types.DataUpdates._
+import org.proof_of_attendance_metagraph.shared_data.types.States._
+import org.tessellation.schema.address.Address
+import org.tessellation.schema.epoch.EpochProgress
+
+//TODO: Implement the correct flow
+object TwitterCombiner {
+  def updateStateTwitterResponse[F[_] : Async](
+    currentCalculatedState: Map[Address, Set[DataSources]],
+    currentEpochProgress  : EpochProgress,
+    twitterUpdate         : TwitterUpdate
+  ): F[Map[Address, Set[DataSources]]] = Async[F].delay {
+    //    def logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromName[F]("TwitterCombiner")
+
+    val twitterDataSource = TwitterDataSource(
+      currentEpochProgress,
+      300, // TBD
+      twitterUpdate.address.value.value
+    )
+    val twitterDataSourceList = Set[DataSources](twitterDataSource)
+    val updatedDataSources = currentCalculatedState
+      .get(twitterUpdate.address)
+      .fold(twitterDataSourceList) { dataSources =>
+        dataSources.collectFirst {
+            case ex: TwitterDataSource => ex
+          }
+          .fold(dataSources + twitterDataSource) { existing =>
+            if (existing.epochProgressToReward.value.value + epoch_progress_1_day < currentEpochProgress.value.value) {
+              dataSources - existing + twitterDataSource
+            } else {
+              dataSources
+            }
+          }
+      }
+    currentCalculatedState + (twitterUpdate.address -> updatedDataSources)
+  }
+}

--- a/modules/shared_data/src/main/scala/org/proof_of_attendance_metagraph/shared_data/types/DataUpdates.scala
+++ b/modules/shared_data/src/main/scala/org/proof_of_attendance_metagraph/shared_data/types/DataUpdates.scala
@@ -2,10 +2,11 @@ package org.proof_of_attendance_metagraph.shared_data.types
 
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
+import io.circe.generic.auto._
 import org.proof_of_attendance_metagraph.shared_data.types.ExolixTypes.ExolixTransaction
+import org.proof_of_attendance_metagraph.shared_data.types.SimplexTypes.SimplexEvent
 import org.tessellation.currency.dataApplication.DataUpdate
 import org.tessellation.schema.address.Address
-import io.circe.generic.auto._
 
 object DataUpdates {
   @derive(encoder, decoder)
@@ -15,13 +16,14 @@ object DataUpdates {
 
   @derive(encoder, decoder)
   case class ExolixUpdate(
-    address: Address,
-    exolixTransaction: ExolixTransaction
+    address           : Address,
+    exolixTransactions: Set[ExolixTransaction]
   ) extends ProofOfAttendanceUpdate
 
   @derive(encoder, decoder)
   case class SimplexUpdate(
-    address: Address,
+    address      : Address,
+    simplexEvents: Set[SimplexEvent]
   ) extends ProofOfAttendanceUpdate
 
   @derive(encoder, decoder)

--- a/modules/shared_data/src/main/scala/org/proof_of_attendance_metagraph/shared_data/types/ExolixTypes.scala
+++ b/modules/shared_data/src/main/scala/org/proof_of_attendance_metagraph/shared_data/types/ExolixTypes.scala
@@ -16,7 +16,14 @@ object ExolixTypes {
     createdAt        : String,
     depositAddress   : String,
     withdrawalAddress: String
-  )
+  ) {
+    override def equals(obj: Any): Boolean = obj match {
+      case that: ExolixTransaction => this.id == that.id
+      case _ => false
+    }
+
+    override def hashCode(): Int = id.hashCode()
+  }
 
   case class ExolixApiResponse(data: List[ExolixTransaction])
 }

--- a/modules/shared_data/src/main/scala/org/proof_of_attendance_metagraph/shared_data/types/SimplexTypes.scala
+++ b/modules/shared_data/src/main/scala/org/proof_of_attendance_metagraph/shared_data/types/SimplexTypes.scala
@@ -1,0 +1,30 @@
+package org.proof_of_attendance_metagraph.shared_data.types
+
+import io.circe.generic.auto._
+import org.tessellation.schema.address.Address
+
+object SimplexTypes {
+  case class Payment(
+    id            : String,
+    status        : String,
+    createdAt     : String,
+    cryptoCurrency: String,
+  )
+
+  case class SimplexEvent(
+    eventId                 : String,
+    name                    : String,
+    blockchainTxnHash       : String,
+    destinationWalletAddress: Address,
+    payment                 : Payment,
+  ) {
+    override def equals(obj: Any): Boolean = obj match {
+      case that: SimplexEvent => this.eventId == that.eventId
+      case _ => false
+    }
+
+    override def hashCode(): Int = eventId.hashCode()
+  }
+
+  case class SimplexApiResponse(data: List[SimplexEvent])
+}

--- a/modules/shared_data/src/main/scala/org/proof_of_attendance_metagraph/shared_data/types/States.scala
+++ b/modules/shared_data/src/main/scala/org/proof_of_attendance_metagraph/shared_data/types/States.scala
@@ -2,12 +2,13 @@ package org.proof_of_attendance_metagraph.shared_data.types
 
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
+import io.circe.generic.auto._
 import org.proof_of_attendance_metagraph.shared_data.types.DataUpdates.ProofOfAttendanceUpdate
 import org.proof_of_attendance_metagraph.shared_data.types.ExolixTypes.ExolixTransaction
+import org.proof_of_attendance_metagraph.shared_data.types.SimplexTypes.SimplexEvent
 import org.tessellation.currency.dataApplication.{DataCalculatedState, DataOnChainState}
 import org.tessellation.schema.address.Address
 import org.tessellation.schema.epoch.EpochProgress
-import io.circe.generic.auto._
 
 object States {
   @derive(encoder, decoder)
@@ -21,7 +22,8 @@ object States {
   case class ExolixDataSource(
     epochProgressToReward: EpochProgress,
     amountToReward       : Long,
-    exolixApiResponse    : ExolixTransaction
+    latestTransactions   : Set[ExolixTransaction],
+    olderTransactions    : Set[ExolixTransaction]
   ) extends DataSources {
     override val name: String = "ExolixDataSource"
 
@@ -35,9 +37,10 @@ object States {
 
   @derive(encoder, decoder)
   case class SimplexDataSource(
-    epochProgressToReward     : EpochProgress,
-    amountToReward            : Long,
-    simplexApiResponseAsString: String
+    epochProgressToReward: EpochProgress,
+    amountToReward       : Long,
+    latestEvents         : Set[SimplexEvent],
+    olderEvents          : Set[SimplexEvent]
   ) extends DataSources {
     override val name: String = "SimplexDataSource"
 


### PR DESCRIPTION
### Changes
+ Refactored the Exolix and Simplex states to store a list of transactions instead of only the latest transaction. This change is necessary to multiply the number of transactions by 35 (the default reward per transaction for these integrations).
+ Updated the state format to include older transactions, allowing us to compare and avoid duplicating transactions/events.
+ Added a new Simplex fetcher that calls a lattice endpoint to return valid Simplex events for the provided date.
+ Refactored the combiners to handle each integration separately, instead of centralizing everything in a single file.
+ Updated the application.config time for the Simplex Daemon to 1 hour.