### PR TITLE
Adding X Data source

### DIFF
--- a/.github/config/changelog.json
+++ b/.github/config/changelog.json
@@ -1,24 +1,34 @@
 {
-    "categories": [
-        {
-            "title": "## 🚀 Features",
-            "labels": ["feature"]
-        },
-        {
-            "title": "## 🐛 Fixes",
-            "labels": ["fix"]
-        },
-        {
-            "title": "## 🧪 Tests",
-            "labels": ["test"]
-        },
-        {
-            "title": "## 📓 Architecture Decision Records",
-            "labels": ["adr"]
-        },
-        {
-            "title": "## 💬 Other",
-            "labels": ["other"]
-        }
-    ]
+  "categories": [
+    {
+      "title": "## 🚀 Features",
+      "labels": [
+        "feature"
+      ]
+    },
+    {
+      "title": "## 🐛 Fixes",
+      "labels": [
+        "fix"
+      ]
+    },
+    {
+      "title": "## 🧪 Tests",
+      "labels": [
+        "test"
+      ]
+    },
+    {
+      "title": "## 📓 Architecture Decision Records",
+      "labels": [
+        "adr"
+      ]
+    },
+    {
+      "title": "## 💬 Other",
+      "labels": [
+        "other"
+      ]
+    }
+  ]
 }

--- a/.github/templates/deploy/action.yml
+++ b/.github/templates/deploy/action.yml
@@ -24,7 +24,7 @@ inputs:
   GITHUB_TOKEN:
     required: true
 
-#Configuration file variables
+  #Configuration file variables
   DATA_API_IP:
     required: true
   DATA_API_PORT:
@@ -63,7 +63,22 @@ inputs:
     required: true
   OUTFLOW_TRANSACTIONS_WORKER_INTERVAL:
     required: true
-
+  X_API_URL:
+    required: true
+  X_API_CONSUMER_KEY:
+    required: true
+  X_API_CONSUMER_SECRET:
+    required: true
+  X_API_ACCESS_TOKEN:
+    required: true
+  X_API_ACCESS_SECRET:
+    required: true
+  USERS_SOURCE_API_URL:
+    required: true
+  X_SEARCH_INFORMATION:
+    required: true
+  X_WORKER_INTERVAL:
+    required: true
 runs:
   using: "composite"
   steps:
@@ -111,6 +126,15 @@ runs:
         export OUTFLOW_TRANSACTIONS_API_URL="${{ inputs.OUTFLOW_TRANSACTIONS_API_URL }}"
         export OUTFLOW_TRANSACTIONS_WALLETS="${{ inputs.OUTFLOW_TRANSACTIONS_WALLETS }}"
         export OUTFLOW_TRANSACTIONS_WORKER_INTERVAL="${{ inputs.OUTFLOW_TRANSACTIONS_WORKER_INTERVAL }}"
+        
+        export X_API_URL="${{ inputs.X_API_URL }}"
+        export X_API_CONSUMER_KEY="${{ inputs.X_API_CONSUMER_KEY }}"
+        export X_API_CONSUMER_SECRET="${{ inputs.X_API_CONSUMER_SECRET }}"
+        export X_API_ACCESS_TOKEN="${{ inputs.X_API_ACCESS_TOKEN }}"
+        export X_API_ACCESS_SECRET="${{ inputs.X_API_ACCESS_SECRET }}"
+        export USERS_SOURCE_API_URL="${{ inputs.USERS_SOURCE_API_URL }}"
+        export X_SEARCH_INFORMATION="${{ inputs.X_SEARCH_INFORMATION }}"
+        export X_WORKER_INTERVAL="${{ inputs.X_WORKER_INTERVAL }}"
 
         cd modules/shared_data/src/main/resources
         envsubst < application.conf > application.conf.tmp

--- a/.github/workflows/deploy-integrationnet.yml
+++ b/.github/workflows/deploy-integrationnet.yml
@@ -40,6 +40,15 @@ jobs:
           OUTFLOW_TRANSACTIONS_WALLETS: ${{ secrets.OUTFLOW_TRANSACTIONS_WALLETS }}
           OUTFLOW_TRANSACTIONS_WORKER_INTERVAL: ${{ secrets.OUTFLOW_TRANSACTIONS_WORKER_INTERVAL }}
 
+          X_API_URL: ${{secrets.X_API_URL}}
+          X_API_CONSUMER_KEY: ${{secrets.X_API_CONSUMER_KEY}}
+          X_API_CONSUMER_SECRET: ${{secrets.X_API_CONSUMER_SECRET}}
+          X_API_ACCESS_TOKEN: ${{secrets.X_API_ACCESS_TOKEN}}
+          X_API_ACCESS_SECRET: ${{secrets.X_API_ACCESS_SECRET}}
+          USERS_SOURCE_API_URL: ${{secrets.USERS_SOURCE_API_URL}}
+          X_SEARCH_INFORMATION: ${{secrets.X_SEARCH_INFORMATION}}
+          X_WORKER_INTERVAL: ${{secrets.X_WORKER_INTERVAL}}
+
           SSH_NODE_1_HOST: ${{ secrets.SSH_HOST_INTNET_1 }}
           SSH_NODE_1_USER: ${{ secrets.SSH_USER_INTNET_1 }}
           SSH_NODE_2_HOST: ${{ secrets.SSH_HOST_INTNET_2 }}

--- a/.github/workflows/deploy-mainnet.yml
+++ b/.github/workflows/deploy-mainnet.yml
@@ -40,6 +40,15 @@ jobs:
           OUTFLOW_TRANSACTIONS_WALLETS: ${{ secrets.OUTFLOW_TRANSACTIONS_WALLETS }}
           OUTFLOW_TRANSACTIONS_WORKER_INTERVAL: ${{ secrets.OUTFLOW_TRANSACTIONS_WORKER_INTERVAL }}
 
+          X_API_URL: ${{secrets.X_API_URL}}
+          X_API_CONSUMER_KEY: ${{secrets.X_API_CONSUMER_KEY}}
+          X_API_CONSUMER_SECRET: ${{secrets.X_API_CONSUMER_SECRET}}
+          X_API_ACCESS_TOKEN: ${{secrets.X_API_ACCESS_TOKEN}}
+          X_API_ACCESS_SECRET: ${{secrets.X_API_ACCESS_SECRET}}
+          USERS_SOURCE_API_URL: ${{secrets.USERS_SOURCE_API_URL}}
+          X_SEARCH_INFORMATION: ${{secrets.X_SEARCH_INFORMATION}}
+          X_WORKER_INTERVAL: ${{secrets.X_WORKER_INTERVAL}}
+
           SSH_NODE_1_HOST: ${{ secrets.SSH_HOST_MAINNET_1 }}
           SSH_NODE_1_USER: ${{ secrets.SSH_USER_MAINNET_1 }}
           SSH_NODE_2_HOST: ${{ secrets.SSH_HOST_MAINNET_2 }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-The Elpaca Metagraph is a social credit metagraph designed to track community activity within the ecosystem and reward positive behaviors with tokens. By incentivizing network participation, the Elpaca Metagraph aims to foster a more engaged and active community.
+The Elpaca Metagraph is a social credit metagraph designed to track community activity within the ecosystem and reward
+positive behaviors with tokens. By incentivizing network participation, the Elpaca Metagraph aims to foster a more
+engaged and active community.
 
 ## Metagraph Functionality
 
@@ -10,7 +12,9 @@ The Elpaca Metagraph periodically fetches data about network participation and a
 
 ## Data Sources and Workers
 
-We have several data sources that are executed using workers/daemons, which are triggered every hour. These workers check for new events, wallets, transactions, and other relevant data. Upon detecting new data, the workers send updates to the metagraph.
+We have several data sources that are executed using workers/daemons, which are triggered every hour. These workers
+check for new events, wallets, transactions, and other relevant data. Upon detecting new data, the workers send updates
+to the metagraph.
 
 Additionally, there are manual data sources that require a `DataUpdate` to be sent manually to the `/data` endpoint.
 
@@ -18,32 +22,49 @@ Additionally, there are manual data sources that require a `DataUpdate` to be se
 
 1. **Exolix Swaps:**
     - **Description:** All wallets that have swapped into DAG will receive credit based on the number of swaps.
-    - **Worker Function:** The Exolix worker checks for new swap transactions every hour and updates the metagraph accordingly.
+    - **Worker Function:** The Exolix worker checks for new swap transactions every hour and updates the metagraph
+      accordingly.
 
 2. **Simplex Purchases:**
-    - **Description:** All wallets that have purchased DAG through Simplex will receive credit based on the number of purchases.
-    - **Worker Function:** The Simplex worker checks for new purchase transactions every hour and updates the metagraph accordingly.
+    - **Description:** All wallets that have purchased DAG through Simplex will receive credit based on the number of
+      purchases.
+    - **Worker Function:** The Simplex worker checks for new purchase transactions every hour and updates the metagraph
+      accordingly.
 
 3. **IntegrationNet Node Operator Line:**
     - **Description:** Wallets with a balance over 250k DAG and whose operators are in the queue will receive credit.
-    - **Worker Function:** The IntegrationNet worker checks the queue status and wallet balances every hour and updates the metagraph accordingly.
+    - **Worker Function:** The IntegrationNet worker checks the queue status and wallet balances every hour and updates
+      the metagraph accordingly.
 
 4. **New Wallet Creation:**
     - **Description:** Wallets created with at least 1,500 DAG and held for 7 days will receive credit.
-    - **Worker Function:** The New Wallet worker checks for new wallet creations and their holding status every hour and updates the metagraph accordingly.
+    - **Worker Function:** The New Wallet worker checks for new wallet creations and their holding status every hour and
+      updates the metagraph accordingly.
 
 5. **Inflow Transactions:**
-   - **Description:** Provided wallets that received transactions great or equal an specific amount of DAG, greater than starting date
-   - **Worker Function:** The worker checks if the provided wallets received any transactions greater than the specified amount of DAG every 30 minutes and updates the metagraph accordingly.
+    - **Description:** Provided wallets that received transactions great or equal an specific amount of DAG, greater
+      than starting date
+    - **Worker Function:** The worker checks if the provided wallets received any transactions greater than the
+      specified amount of DAG every 30 minutes and updates the metagraph accordingly.
 
 6. **Outflow Transactions:**
-   - **Description:** Provided wallets that sent transactions great or equal an specific amount of DAG, greater than starting date.
-   - **Worker Function:** The worker checks if the provided wallets received any transactions greater than the specified amount of DAG every 30 minutes and updates the metagraph accordingly.
+    - **Description:** Provided wallets that sent transactions great or equal an specific amount of DAG, greater than
+      starting date.
+    - **Worker Function:** The worker checks if the provided wallets received any transactions greater than the
+      specified amount of DAG every 30 minutes and updates the metagraph accordingly.
+7. **X Posts:**
+   - **Description:** Users who have linked their X/Twitter accounts in Lattice can receive rewards based on the 
+      content of their posts.
+   - **Worker Function:** The worker will monitor user posts for specific strings and reward them accordingly. 
+      The configuration of the worker determines which strings to monitor, the maximum number of rewards per day,
+      and the reward amount. This worker will run every 30 minutes.
 
 ### Manual Data Sources
 
 1. **All Wallets:**
-    - **Description:** All new and existing wallets will receive 1 token. For retroactive/existing wallets, the tokens will be distributed automatically. However, for new wallets, you need to provide an update to the metagraph to process the wallet and distribute the token.
+    - **Description:** All new and existing wallets will receive 1 token. For retroactive/existing wallets, the tokens
+      will be distributed automatically. However, for new wallets, you need to provide an update to the metagraph to
+      process the wallet and distribute the token.
     - **Expected Update:** For new wallets, send the following update to the metagraph:
 
 ```json
@@ -72,6 +93,7 @@ Additionally, there are manual data sources that require a `DataUpdate` to be se
 - **All Wallets:** 1 token per wallet.
 - **Inflow Transactions:** Defined in configuration.
 - **Outflow Transactions:** Defined in configuration.
+- **X/Twitter Posts:** Defined in configuration.
 
 ## Worker/Daemon Functionality
 
@@ -79,11 +101,14 @@ Some data source has an associated worker/daemon that performs the following tas
 
 1. **Check for Updates:** The worker queries the relevant data source for any new events, wallets, transactions, etc.
 2. **Process Data:** The worker processes the fetched data to determine eligibility for rewards.
-3. **Send Updates:** The worker sends the processed data to the metagraph, updating it with new information and minting tokens as necessary.
+3. **Send Updates:** The worker sends the processed data to the metagraph, updating it with new information and minting
+   tokens as necessary.
 
-This hourly checking mechanism ensures that the metagraph remains up-to-date with the latest network activity, accurately rewarding community members for their participation.
-
+This hourly checking mechanism ensures that the metagraph remains up-to-date with the latest network activity,
+accurately rewarding community members for their participation.
 
 ## Conclusion
 
-The Elpaca Metagraph leverages these data sources and workers to create a dynamic and responsive system that rewards positive behavior within the ecosystem. By continuously monitoring and updating the metagraph, we ensure that the community's efforts are recognized and incentivized.
+The Elpaca Metagraph leverages these data sources and workers to create a dynamic and responsive system that rewards
+positive behavior within the ecosystem. By continuously monitoring and updating the metagraph, we ensure that the
+community's efforts are recognized and incentivized.

--- a/build.sbt
+++ b/build.sbt
@@ -45,8 +45,6 @@ lazy val sharedData = (project in file("modules/shared_data"))
       CompilerPlugin.betterMonadicFor,
       CompilerPlugin.semanticDB,
       Libraries.tessellationNodeShared,
-      Libraries.requests,
-      Libraries.upickle,
       Libraries.scribeJavaCore,
       Libraries.scribeJavaApis
     )

--- a/build.sbt
+++ b/build.sbt
@@ -18,9 +18,6 @@ ThisBuild / assemblyMergeStrategy := {
 lazy val commonTestSettings = Seq(
   testFrameworks += new TestFramework("weaver.framework.CatsEffect"),
   libraryDependencies ++= Seq(
-    Libraries.weaverCats,
-    Libraries.weaverDiscipline,
-    Libraries.weaverScalaCheck,
     Libraries.catsEffectTestkit
   ).map(_ % Test)
 )
@@ -49,7 +46,9 @@ lazy val sharedData = (project in file("modules/shared_data"))
       CompilerPlugin.semanticDB,
       Libraries.tessellationNodeShared,
       Libraries.requests,
-      Libraries.upickle
+      Libraries.upickle,
+      Libraries.scribeJavaCore,
+      Libraries.scribeJavaApis
     )
   )
 lazy val currencyL1 = (project in file("modules/l1"))

--- a/modules/l0/src/main/scala/org/elpaca_metagraph/l0/Main.scala
+++ b/modules/l0/src/main/scala/org/elpaca_metagraph/l0/Main.scala
@@ -39,7 +39,7 @@ object Main extends CurrencyL0App(
     keyPair <- loadKeyPair[IO](config).asResource
     calculatedStateService <- CalculatedStateService.make[IO].asResource
     _ <- DaemonApis.make[IO](config, keyPair).spawnL0Daemons(calculatedStateService).asResource
-    l0Service <- MetagraphL0Service.make[IO](calculatedStateService).asResource
+    l0Service <- MetagraphL0Service.make[IO](calculatedStateService, config).asResource
   } yield l0Service).some
 
 

--- a/modules/l0/src/main/scala/org/elpaca_metagraph/l0/MetagraphL0Service.scala
+++ b/modules/l0/src/main/scala/org/elpaca_metagraph/l0/MetagraphL0Service.scala
@@ -10,6 +10,7 @@ import io.circe.{Decoder, Encoder}
 import org.elpaca_metagraph.l0.custom_routes.CustomRoutes
 import org.elpaca_metagraph.shared_data.LifecycleSharedFunctions
 import org.elpaca_metagraph.shared_data.Utils.toTokenAmountFormat
+import org.elpaca_metagraph.shared_data.app.ApplicationConfig
 import org.elpaca_metagraph.shared_data.calculated_state.CalculatedStateService
 import org.elpaca_metagraph.shared_data.types.DataUpdates._
 import org.elpaca_metagraph.shared_data.types.ExistingWallets.ExistingWalletsDataSourceAddress
@@ -33,16 +34,19 @@ import scala.io.Source
 object MetagraphL0Service {
 
   def make[F[+_] : Async : JsonSerializer](
-    calculatedStateService: CalculatedStateService[F]
+    calculatedStateService: CalculatedStateService[F],
+    applicationConfig     : ApplicationConfig
   ): F[BaseDataApplicationL0Service[F]] = Async[F].delay {
     makeBaseDataApplicationL0Service(
-      calculatedStateService
+      calculatedStateService,
+      applicationConfig
     )
   }
 
 
   private def makeBaseDataApplicationL0Service[F[+_] : Async : JsonSerializer](
-    calculatedStateService: CalculatedStateService[F]
+    calculatedStateService: CalculatedStateService[F],
+    applicationConfig     : ApplicationConfig
   ): BaseDataApplicationL0Service[F] =
     BaseDataApplicationL0Service(
       new DataApplicationL0Service[F, ElpacaUpdate, ElpacaOnChainState, ElpacaCalculatedState] {
@@ -108,7 +112,8 @@ object MetagraphL0Service {
         )(implicit context: L0NodeContext[F]): F[DataState[ElpacaOnChainState, ElpacaCalculatedState]] =
           LifecycleSharedFunctions.combine[F](
             state,
-            updates
+            updates,
+            applicationConfig
           )
 
         override def dataEncoder: Encoder[ElpacaUpdate] =

--- a/modules/l0/src/main/scala/org/elpaca_metagraph/l0/custom_routes/CustomRoutes.scala
+++ b/modules/l0/src/main/scala/org/elpaca_metagraph/l0/custom_routes/CustomRoutes.scala
@@ -37,7 +37,8 @@ case class CustomRoutes[F[_] : Async](calculatedStateService: CalculatedStateSer
       "freshwallets" -> FreshWallet,
       "existingwallets" -> ExistingWallets,
       "inflowtransactions" -> InflowTransactions,
-      "outflowtransactions" -> OutflowTransactions
+      "outflowtransactions" -> OutflowTransactions,
+      "x" -> X
     )
 
     calculatedStateService

--- a/modules/shared_data/src/main/resources/application.conf
+++ b/modules/shared_data/src/main/resources/application.conf
@@ -45,6 +45,17 @@ outflow-transactions-daemon {
   idle-time = ${OUTFLOW_TRANSACTIONS_WORKER_INTERVAL}
 }
 
+x-daemon {
+  x-api-url = "${X_API_URL}"
+  x-api-consumer-key = "${X_API_CONSUMER_KEY}"
+  x-api-consumer-secret = "${X_API_CONSUMER_SECRET}"
+  x-api-access-token = "${X_API_ACCESS_TOKEN}"
+  x-api-access-secret = "${X_API_ACCESS_SECRET}"
+  users-source-api-url = "${USERS_SOURCE_API_URL}"
+  search-information = ${X_SEARCH_INFORMATION}
+  idle-time = ${X_WORKER_INTERVAL}
+}
+
 node-key {
   keystore = CL_KEYSTORE_PLACEHOLDER
   alias = CL_KEYALIAS_PLACEHOLDER

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/Utils.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/Utils.scala
@@ -17,6 +17,7 @@ import java.security.KeyPair
 
 
 object Utils {
+  val epochProgressOneDay: Long = 60 * 24
   def logger[F[_] : Async]: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromName[F]("Utils")
 
   def toTokenFormat(

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/app/ApplicationConfig.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/app/ApplicationConfig.scala
@@ -19,7 +19,8 @@ case class ApplicationConfig(
   walletCreationHoldingDagDaemon    : ApplicationConfig.WalletCreationHoldingDagDaemonConfig,
   inflowTransactionsDaemon          : ApplicationConfig.InflowTransactionsDaemonConfig,
   outflowTransactionsDaemon         : ApplicationConfig.OutflowTransactionsDaemonConfig,
-  nodeKey                           : ApplicationConfig.NodeKey
+  nodeKey                           : ApplicationConfig.NodeKey,
+  xDaemon                           : ApplicationConfig.XDaemonConfig
 )
 
 object ApplicationConfig {
@@ -73,6 +74,23 @@ object ApplicationConfig {
     idleTime   : FiniteDuration,
     apiUrl     : Option[ApiUrl],
     walletsInfo: List[WalletsInfo]
+  )
+
+  case class XSearchInfo(
+    text        : String,
+    rewardAmount: Amount,
+    maxPerDay   : Long
+  )
+
+  case class XDaemonConfig(
+    idleTime          : FiniteDuration,
+    usersSourceApiUrl : Option[ApiUrl],
+    xApiUrl           : Option[ApiUrl],
+    xApiConsumerKey   : Option[String],
+    xApiConsumerSecret: Option[String],
+    xApiAccessToken   : Option[String],
+    xApiAccessSecret  : Option[String],
+    searchInformation : List[XSearchInfo]
   )
 
   case class NodeKey(

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/app/ApplicationConfigOps.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/app/ApplicationConfigOps.scala
@@ -56,6 +56,8 @@ object ConfigReaders {
   implicit val walletsInfoReader: ConfigReader[ApplicationConfig.WalletsInfo] = deriveReader
   implicit val inflowTransactionsDaemonConfigReader: ConfigReader[ApplicationConfig.InflowTransactionsDaemonConfig] = deriveReader
   implicit val outflowTransactionsDaemonConfigReader: ConfigReader[ApplicationConfig.OutflowTransactionsDaemonConfig] = deriveReader
+  implicit val xSearchInfoReader: ConfigReader[ApplicationConfig.XSearchInfo] = deriveReader
+  implicit val xDaemonConfigReader: ConfigReader[ApplicationConfig.XDaemonConfig] = deriveReader
   implicit val nodeKeyReader: ConfigReader[ApplicationConfig.NodeKey] = deriveReader
   implicit val clientConfigReader: ConfigReader[HttpClientConfig] = deriveReader
   implicit val http4sConfigReader: ConfigReader[ApplicationConfig.Http4sConfig] = deriveReader

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/combiners/SimplexCombiner.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/combiners/SimplexCombiner.scala
@@ -2,10 +2,10 @@ package org.elpaca_metagraph.shared_data.combiners
 
 import cats.effect.Async
 import cats.syntax.all._
-import org.elpaca_metagraph.shared_data.Utils.{toTokenAmountFormat, toTokenFormat}
+import org.elpaca_metagraph.shared_data.Utils.toTokenAmountFormat
 import org.elpaca_metagraph.shared_data.types.DataUpdates.SimplexUpdate
-import org.elpaca_metagraph.shared_data.types.States._
 import org.elpaca_metagraph.shared_data.types.Simplex._
+import org.elpaca_metagraph.shared_data.types.States._
 import org.tessellation.schema.address.Address
 import org.tessellation.schema.epoch.EpochProgress
 import org.typelevel.log4cats.Logger
@@ -90,6 +90,6 @@ object SimplexCombiner {
     simplexUpdate         : SimplexUpdate
   ): F[SimplexDataSource] =
     getSimplexDataSourceUpdatedAddresses(currentCalculatedState, simplexUpdate, currentEpochProgress).map { updatedAddresses =>
-        SimplexDataSource(updatedAddresses)
+      SimplexDataSource(updatedAddresses)
     }
 }

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/combiners/XCombiner.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/combiners/XCombiner.scala
@@ -1,0 +1,150 @@
+package org.elpaca_metagraph.shared_data.combiners
+
+import cats.syntax.all._
+import monocle.Monocle.toAppliedFocusOps
+import org.elpaca_metagraph.shared_data.Utils.{epochProgressOneDay, toTokenAmountFormat}
+import org.elpaca_metagraph.shared_data.app.ApplicationConfig
+import org.elpaca_metagraph.shared_data.types.DataUpdates._
+import org.elpaca_metagraph.shared_data.types.States._
+import org.elpaca_metagraph.shared_data.types.X.{XDataSourceAddress, XRewardInfo}
+import org.tessellation.schema.balance.Amount
+import org.tessellation.schema.epoch.EpochProgress
+
+object XCombiner {
+  private val firstPostOfTheDay: Long = 1L
+
+  private def createXRewardInfo(
+    currentEpochProgress: EpochProgress,
+    xUpdate             : XUpdate,
+    rewardAmount        : Amount
+  ): XRewardInfo = {
+    XRewardInfo(
+      currentEpochProgress,
+      currentEpochProgress,
+      toTokenAmountFormat(rewardAmount),
+      xUpdate.searchText,
+      List(xUpdate.postId),
+      firstPostOfTheDay
+    )
+  }
+
+  private def getCurrentXDataSource(
+    currentCalculatedState: Map[DataSourceType, DataSource]
+  ): XDataSource = {
+    currentCalculatedState
+      .get(DataSourceType.X) match {
+      case Some(xDataSource: XDataSource) => xDataSource
+      case _ => XDataSource(Map.empty)
+    }
+  }
+
+  def updateRewardsOlderThanOneDay(
+    currentCalculatedState: Map[DataSourceType, DataSource],
+    currentEpochProgress  : EpochProgress
+  ): Map[DataSourceType, DataSource] = {
+    val xDataSource = getCurrentXDataSource(currentCalculatedState)
+
+    val updatedXDataSourceAddresses = xDataSource.existingWallets.foldLeft(xDataSource.existingWallets) { (acc, current) =>
+      val (address, xDataSourceAddress) = current
+      val updatedRewards = xDataSourceAddress.addressRewards.foldLeft(xDataSourceAddress.addressRewards) { (innerAcc, innerCurrent) =>
+        val (searchText, rewardInfo) = innerCurrent
+        if (rewardInfo.dailyEpochProgress.value.value + epochProgressOneDay <= currentEpochProgress.value.value) {
+          innerAcc
+            .updated(searchText, rewardInfo
+              .focus(_.dailyPostsNumber).replace(0)
+            )
+        } else {
+          innerAcc
+        }
+      }
+
+      acc.updated(
+        address,
+        xDataSourceAddress.focus(_.addressRewards).replace(updatedRewards)
+      )
+    }
+    currentCalculatedState
+      .updated(DataSourceType.X, xDataSource.focus(_.existingWallets).replace(updatedXDataSourceAddresses))
+  }
+
+  def updateStateX(
+    currentCalculatedState: Map[DataSourceType, DataSource],
+    currentEpochProgress  : EpochProgress,
+    xUpdate               : XUpdate,
+    applicationConfig     : ApplicationConfig
+  ): XDataSource = {
+    val xDataSource = getCurrentXDataSource(currentCalculatedState)
+
+    val xDataSourceAddress = xDataSource.existingWallets
+      .get(xUpdate.address) match {
+      case Some(xDataSourceAddress) => xDataSourceAddress
+      case None => XDataSourceAddress.empty
+    }
+
+    val maybeSearchInformation = applicationConfig.xDaemon.searchInformation
+      .find(_.text == xUpdate.searchText)
+
+    maybeSearchInformation.fold(xDataSource) { searchInformation =>
+      val updatedData = xDataSourceAddress.addressRewards
+        .get(xUpdate.searchText)
+        .map { data =>
+          def isNewDay = data.epochProgressToReward.value.value + epochProgressOneDay < currentEpochProgress.value.value
+
+          def updateXRewardInfoNewDay() = {
+            data
+              .focus(_.dailyEpochProgress)
+              .replace(currentEpochProgress)
+              .focus(_.epochProgressToReward)
+              .replace(currentEpochProgress)
+              .focus(_.dailyPostsNumber)
+              .replace(firstPostOfTheDay)
+              .focus(_.amountToReward)
+              .replace(toTokenAmountFormat(searchInformation.rewardAmount))
+              .focus(_.postIds)
+              .replace(List(xUpdate.postId))
+          }
+
+          def isNotExceedingDailyLimit = data.dailyPostsNumber < searchInformation.maxPerDay
+          def postAlreadyExists = data.postIds.contains(xUpdate.postId)
+
+          def updateXRewardInfoSameDay() = {
+            //If we receive multiple updates to the same address in the same epoch progress we need to increase the rewardAmount
+            if (data.epochProgressToReward === currentEpochProgress) {
+              data
+                .focus(_.dailyPostsNumber)
+                .modify(current => current + 1)
+                .focus(_.amountToReward)
+                .modify(current => current.plus(toTokenAmountFormat(searchInformation.rewardAmount)).getOrElse(current))
+                .focus(_.postIds)
+                .modify(current => current :+ xUpdate.postId)
+            } else {
+              data
+                .focus(_.epochProgressToReward)
+                .replace(currentEpochProgress)
+                .focus(_.dailyPostsNumber)
+                .modify(current => current + 1)
+                .focus(_.postIds)
+                .modify(current => current :+ xUpdate.postId)
+            }
+          }
+
+          if (isNewDay) {
+            updateXRewardInfoNewDay()
+          } else if (isNotExceedingDailyLimit && !postAlreadyExists) {
+            updateXRewardInfoSameDay()
+          } else {
+            data
+          }
+        }
+        .getOrElse(createXRewardInfo(currentEpochProgress, xUpdate, searchInformation.rewardAmount))
+
+      val updatedDataSourceAddress = xDataSourceAddress
+        .focus(_.addressRewards)
+        .modify(_.updated(xUpdate.searchText, updatedData))
+
+      xDataSource
+        .focus(_.existingWallets)
+        .modify(_.updated(xUpdate.address, updatedDataSourceAddress))
+    }
+  }
+}

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/DaemonApis.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/DaemonApis.scala
@@ -61,7 +61,8 @@ object DaemonApis {
         logger.info("Spawning L0 daemons") >>
           spawnWalletCreationDaemon(config, signer, calculatedStateService) >>
           spawnInflowTransactionsDaemon(config, signer, calculatedStateService) >>
-          spawnOutflowTransactionsDaemon(config, signer, calculatedStateService)
+          spawnOutflowTransactionsDaemon(config, signer, calculatedStateService) >>
+          spawnXDaemon(config, signer, calculatedStateService)
       }
 
     private def spawn(
@@ -134,6 +135,17 @@ object DaemonApis {
       val outflowTransactionsProcessor = Processor.make[F](outflowTransactionsFetcher, signer)
       logger.info("Spawning Outflow Transactions daemon") >>
         spawn(outflowTransactionsProcessor, config.inflowTransactionsDaemon.idleTime).start
+    }
+
+    private def spawnXDaemon(
+      config                : ApplicationConfig,
+      signer                : Signer[F],
+      calculatedStateService: CalculatedStateService[F]
+    ): F[Unit] = {
+      val xFetcher = XFetcher.make[F](config, calculatedStateService)
+      val outflowTransactionsProcessor = Processor.make[F](xFetcher, signer)
+      logger.info("Spawning X daemon") >>
+        spawn(outflowTransactionsProcessor, config.xDaemon.idleTime).start
     }
   }
 }

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/ExolixFetcher.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/ExolixFetcher.scala
@@ -22,7 +22,7 @@ import java.time.format.DateTimeFormatter
 
 object ExolixFetcher {
 
-  def make[F[_] : Async: Network](applicationConfig: ApplicationConfig): Fetcher[F] =
+  def make[F[_] : Async : Network](applicationConfig: ApplicationConfig): Fetcher[F] =
     new Fetcher[F] {
       private val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromClass(ExolixFetcher.getClass)
 

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/IntegrationnetNodesOperatorsFetcher.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/IntegrationnetNodesOperatorsFetcher.scala
@@ -19,7 +19,7 @@ import java.time.LocalDateTime
 
 object IntegrationnetNodesOperatorsFetcher {
 
-  def make[F[_] : Async: Network](applicationConfig: ApplicationConfig): Fetcher[F] =
+  def make[F[_] : Async : Network](applicationConfig: ApplicationConfig): Fetcher[F] =
     new Fetcher[F] {
       private val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromClass(IntegrationnetNodesOperatorsFetcher.getClass)
 

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/OutflowTransactionsFetcher.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/OutflowTransactionsFetcher.scala
@@ -23,7 +23,7 @@ import java.time.{LocalDateTime, ZonedDateTime}
 
 object OutflowTransactionsFetcher {
 
-  def make[F[_] : Async: Network](
+  def make[F[_] : Async : Network](
     applicationConfig     : ApplicationConfig,
     calculatedStateService: CalculatedStateService[F]
   ): Fetcher[F] =

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/SimplexFetcher.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/SimplexFetcher.scala
@@ -20,7 +20,7 @@ import java.time.format.DateTimeFormatter
 
 object SimplexFetcher {
 
-  def make[F[_] : Async: Network](applicationConfig: ApplicationConfig): Fetcher[F] =
+  def make[F[_] : Async : Network](applicationConfig: ApplicationConfig): Fetcher[F] =
     new Fetcher[F] {
       private val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromClass(SimplexFetcher.getClass)
 

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/WalletCreationHoldingDAGFetcher.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/WalletCreationHoldingDAGFetcher.scala
@@ -22,7 +22,7 @@ import java.time.LocalDateTime
 
 object WalletCreationHoldingDAGFetcher {
 
-  def make[F[_] : Async: Network](
+  def make[F[_] : Async : Network](
     applicationConfig     : ApplicationConfig,
     calculatedStateService: CalculatedStateService[F]
   ): Fetcher[F] =

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/XFetcher.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/XFetcher.scala
@@ -1,0 +1,194 @@
+package org.elpaca_metagraph.shared_data.daemons.fetcher
+
+
+import cats.effect.{Async, Resource}
+import cats.syntax.all._
+import com.github.scribejava.apis.TwitterApi
+import com.github.scribejava.core.builder.ServiceBuilder
+import com.github.scribejava.core.model.{OAuth1AccessToken, OAuthRequest, Verb}
+import com.github.scribejava.core.oauth.OAuth10aService
+import fs2.io.net.Network
+import io.circe.generic.auto._
+import org.elpaca_metagraph.shared_data.app.ApplicationConfig
+import org.elpaca_metagraph.shared_data.calculated_state.CalculatedStateService
+import org.elpaca_metagraph.shared_data.types.DataUpdates.{ElpacaUpdate, XUpdate}
+import org.elpaca_metagraph.shared_data.types.Refined.ApiUrl
+import org.elpaca_metagraph.shared_data.types.States.{DataSourceType, XDataSource}
+import org.elpaca_metagraph.shared_data.types.X._
+import org.http4s._
+import org.http4s.circe._
+import org.http4s.client.Client
+import org.tessellation.node.shared.resources.MkHttpClient
+import org.tessellation.schema.address.Address
+import org.typelevel.ci.CIString
+import org.typelevel.log4cats.SelfAwareStructuredLogger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import scala.jdk.CollectionConverters._
+
+object XFetcher {
+
+  def make[F[_] : Async : Network](
+    applicationConfig     : ApplicationConfig,
+    calculatedStateService: CalculatedStateService[F]
+  ): Fetcher[F] =
+    new Fetcher[F] {
+      private val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromClass(XFetcher.getClass)
+
+      def fetchAllSourceUsers(
+        baseUrl         : ApiUrl,
+        initialOffset   : Long = 0,
+        accumulatedUsers: List[SourceUser] = List.empty
+      ): F[List[SourceUser]] = {
+        val clientResource: Resource[F, Client[F]] = MkHttpClient.forAsync[F].newEmber(applicationConfig.http4s.client)
+        val usersPerRequest: Long = 100
+        clientResource.use { client =>
+          val requestURI = Uri.unsafeFromString(baseUrl.toString())
+            .withQueryParam("limit", usersPerRequest)
+            .withQueryParam("offset", initialOffset)
+
+          val request = Request[F](
+            method = Method.GET,
+            uri = requestURI
+          )
+
+          client.expect[SourceUsersApiResponse](request)(jsonOf[F, SourceUsersApiResponse]).flatMap { response =>
+            val newUsers = accumulatedUsers ++ response.data
+            if (response.meta.offset + response.meta.limit < response.meta.total) {
+              fetchAllSourceUsers(baseUrl, response.meta.offset + response.meta.limit, newUsers)
+            } else {
+              newUsers.pure
+            }
+          }
+        }
+      }
+
+      def fetchXPosts(
+        url               : ApiUrl,
+        username          : String,
+        xApiConsumerKey   : String,
+        xApiConsumerSecret: String,
+        xApiAccessToken   : String,
+        xApiAccessSecret  : String,
+        currentDateTime   : LocalDateTime
+      ):
+      F[List[XPost]] = {
+        val clientResource: Resource[F, Client[F]] = MkHttpClient.forAsync[F].newEmber(applicationConfig.http4s.client)
+
+        val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+        val dateTimeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
+        val currentDateFormatted: String = currentDateTime.format(dateFormatter)
+        val currentDateTimeFormatted: String = currentDateTime.minusMinutes(1).format(dateTimeFormatter)
+
+        val service: OAuth10aService = new ServiceBuilder(xApiConsumerKey)
+          .apiSecret(xApiConsumerSecret)
+          .build(TwitterApi.instance())
+
+        clientResource.use { client =>
+          val query = s"from:$username"
+          val requestURI = Uri.unsafeFromString(url.toString()).withQueryParam("query", query)
+            .withQueryParam("start_time", s"${currentDateFormatted}T00:00:00Z")
+            .withQueryParam("end_time", s"$currentDateTimeFormatted")
+            .withQueryParam("tweet.fields", "note_tweet")
+
+          val oauthRequest = new OAuthRequest(Verb.GET, requestURI.toString())
+          val token = new OAuth1AccessToken(xApiAccessToken, xApiAccessSecret)
+          service.signRequest(token, oauthRequest)
+
+          val headers = oauthRequest.getHeaders.entrySet().asScala.foldLeft(List.empty[Header.Raw]) { (acc, entry) =>
+            acc :+ Header.Raw(CIString(entry.getKey), entry.getValue)
+          }
+
+          val signedRequest = Request[F](
+            method = Method.GET,
+            uri = Uri.unsafeFromString(oauthRequest.getCompleteUrl)
+          ).withHeaders(headers)
+
+          client.expect[XApiResponse](signedRequest)(jsonOf[F, XApiResponse]).map(_.data.getOrElse(List.empty[XPost]))
+        }
+      }
+
+      override def getAddressesAndBuildUpdates(currentDateTime: LocalDateTime): F[List[ElpacaUpdate]] = {
+        val xConfig = applicationConfig.xDaemon
+
+        def validateIfAddressCanProceed(
+          xDataSource      : XDataSource,
+          searchInformation: List[ApplicationConfig.XSearchInfo],
+          address          : Address,
+          maybePostId      : Option[String]
+        ): Boolean =
+          xDataSource.existingWallets.get(address).fold(true) { existingWallet =>
+            searchInformation.exists { searchInfo =>
+              existingWallet.addressRewards.get(searchInfo.text).fold(true) { addressRewards =>
+                addressRewards.dailyPostsNumber < searchInfo.maxPerDay &&
+                  maybePostId.forall(!addressRewards.postIds.contains(_))
+              }
+            }
+          }
+
+        for {
+          usersSourceApiUrl <- xConfig.usersSourceApiUrl.toOptionT.getOrRaise(new Exception(s"Could not get usersSourceApiUrl"))
+          xApiUrl <- xConfig.xApiUrl.toOptionT.getOrRaise(new Exception(s"Could not get xApiUrl"))
+          xApiConsumerKey <- xConfig.xApiConsumerKey.toOptionT.getOrRaise(new Exception(s"Could not get xApiConsumerKey"))
+          xApiConsumerSecret <- xConfig.xApiConsumerSecret.toOptionT.getOrRaise(new Exception(s"Could not get xApiConsumerSecret"))
+          xApiAccessToken <- xConfig.xApiAccessToken.toOptionT.getOrRaise(new Exception(s"Could not get xApiAccessToken"))
+          xApiAccessSecret <- xConfig.xApiAccessSecret.toOptionT.getOrRaise(new Exception(s"Could not get xApiAccessSecret"))
+
+          calculatedState <- calculatedStateService.get
+          xDataSource: XDataSource = calculatedState.state.dataSources
+            .get(DataSourceType.X)
+            .collect { case ds: XDataSource => ds }
+            .getOrElse(XDataSource(Map.empty))
+
+          searchInformation = xConfig.searchInformation
+
+          sourceUsers <- fetchAllSourceUsers(usersSourceApiUrl)
+          sourceUsersFiltered = sourceUsers.filter { user =>
+            user.primaryDagAddress.flatMap { address =>
+              user.twitter.map { _ =>
+                validateIfAddressCanProceed(xDataSource, searchInformation, address, none)
+              }
+            }.getOrElse(false)
+          }
+
+          _ <- logger.info(s"Found ${sourceUsers.length} sourceUsers")
+          _ <- logger.info(s"Found ${sourceUsersFiltered.length} sourceUsersFiltered")
+
+          xPosts <- sourceUsersFiltered.traverse { userInfo =>
+            val username = userInfo.twitter.get.username
+            val primaryDAGAddress = userInfo.primaryDagAddress.get
+            fetchXPosts(xApiUrl, username, xApiConsumerKey, xApiConsumerSecret, xApiAccessToken, xApiAccessSecret, currentDateTime)
+              .handleErrorWith { err =>
+                logger.error(err)(s"Error when fetching XPosts for user: $username").as(List.empty[XPost])
+              }
+              .map { xPosts =>
+                xPosts.flatMap { xPost =>
+                  val completePost = xPost.note_tweet.map(_.text).getOrElse(xPost.text)
+                  searchInformation.collect {
+                    case searchInfo if completePost.contains(searchInfo.text) =>
+                      XDataInfo(
+                        xPost.id,
+                        primaryDAGAddress,
+                        searchInfo.text,
+                        searchInfo.maxPerDay
+                      )
+                  }
+                }
+              }
+          }.map(_.flatten)
+
+          _ <- logger.info(s"Found ${xPosts.length} x posts")
+
+          filteredXPosts = xPosts.filter { xPost =>
+            validateIfAddressCanProceed(xDataSource, searchInformation, xPost.dagAddress, xPost.postId.some)
+          }
+          _ <- logger.info(s"Found ${filteredXPosts.length} valid x posts: ${filteredXPosts}")
+          dataUpdates = filteredXPosts.foldLeft(List.empty[XUpdate]) { (acc, info) =>
+            acc :+ XUpdate(info.dagAddress, info.searchText, info.postId)
+          }
+        } yield dataUpdates
+      }
+    }
+}

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/DataUpdates.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/DataUpdates.scala
@@ -60,4 +60,11 @@ object DataUpdates {
     rewardAddress: Address,
     rewardAmount : Amount
   ) extends ElpacaUpdate
+
+  @derive(encoder, decoder)
+  case class XUpdate(
+    address   : Address,
+    searchText: String,
+    postId    : String
+  ) extends ElpacaUpdate
 }

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/Refined.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/Refined.scala
@@ -6,6 +6,7 @@ import eu.timepit.refined.string._
 
 object Refined {
   type ApiUrl = String Refined Uri
+
   object ApiUrl {
     def from(s: String): Either[String, ApiUrl] = refineV[Uri](s)
 

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/States.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/States.scala
@@ -14,6 +14,7 @@ import org.elpaca_metagraph.shared_data.types.IntegrationnetOperators.Integratio
 import org.elpaca_metagraph.shared_data.types.OutflowTransactions.OutflowTransactionsDataSourceAddress
 import org.elpaca_metagraph.shared_data.types.Simplex.SimplexDataSourceAddress
 import org.elpaca_metagraph.shared_data.types.WalletCreationHoldingDAG.WalletCreationHoldingDAGDataSourceAddress
+import org.elpaca_metagraph.shared_data.types.X.XDataSourceAddress
 import org.tessellation.currency.dataApplication.{DataCalculatedState, DataOnChainState}
 import org.tessellation.schema.address.Address
 
@@ -41,8 +42,9 @@ object States {
     case object InflowTransactions extends DataSourceType("InflowTransactions")
 
     case object OutflowTransactions extends DataSourceType("OutflowTransactions")
-  }
 
+    case object X extends DataSourceType("X")
+  }
 
   @derive(encoder, decoder)
   sealed trait DataSource
@@ -85,6 +87,11 @@ object States {
   @derive(encoder, decoder)
   case class OutflowTransactionsDataSource(
     existingWallets: Map[Address, OutflowTransactionsDataSourceAddress]
+  ) extends DataSource
+
+  @derive(encoder, decoder)
+  case class XDataSource(
+    existingWallets: Map[Address, XDataSourceAddress]
   ) extends DataSource
 
   @derive(encoder, decoder)

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/X.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/X.scala
@@ -1,0 +1,87 @@
+package org.elpaca_metagraph.shared_data.types
+
+import derevo.circe.magnolia.{decoder, encoder}
+import derevo.derive
+import org.tessellation.schema.address.Address
+import org.tessellation.schema.balance.Amount
+import org.tessellation.schema.epoch.EpochProgress
+
+object X {
+  @derive(encoder, decoder)
+  case class XRewardInfo(
+    dailyEpochProgress   : EpochProgress,
+    epochProgressToReward: EpochProgress,
+    amountToReward       : Amount,
+    searchText           : String,
+    postIds              : List[String],
+    dailyPostsNumber     : Long,
+  )
+
+
+  @derive(encoder, decoder)
+  case class XDataSourceAddress(
+    addressRewards: Map[String, XRewardInfo]
+  )
+
+  object XDataSourceAddress {
+    def empty: XDataSourceAddress = XDataSourceAddress(Map.empty)
+  }
+
+  @derive(encoder, decoder)
+  case class XUser(
+    id      : String,
+    name    : String,
+    username: String
+  )
+
+  @derive(encoder, decoder)
+  case class SourceUser(
+    id               : String,
+    primaryDagAddress: Option[Address],
+    twitter          : Option[XUser]
+  )
+
+  @derive(encoder, decoder)
+  case class SourceUserMeta(
+    total : Long,
+    limit : Long,
+    offset: Long
+  )
+
+  @derive(encoder, decoder)
+  case class SourceUsersApiResponse(
+    data: List[SourceUser],
+    meta: SourceUserMeta
+  )
+
+  @derive(encoder, decoder)
+  case class NoteTweet(
+    text: String
+  )
+
+  @derive(encoder, decoder)
+  case class XPost(
+    id        : String,
+    text      : String,
+    note_tweet: Option[NoteTweet]
+  )
+
+  @derive(encoder, decoder)
+  case class XApiResponseMetadata(
+    result_count: Long
+  )
+
+  @derive(encoder, decoder)
+  case class XApiResponse(
+    data: Option[List[XPost]],
+    meta: XApiResponseMetadata
+  )
+
+  @derive(encoder, decoder)
+  case class XDataInfo(
+    postId               : String,
+    dagAddress           : Address,
+    searchText           : String,
+    limitSearchTextPerDay: Long
+  )
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt.*
 object Dependencies {
 
   object V {
-    val tessellation = "2.8.0"
+    val tessellation = "2.8.1"
     val decline = "2.4.1"
   }
 
@@ -21,8 +21,6 @@ object Dependencies {
     val declineCore = decline()
     val declineEffect = decline("effect")
     val declineRefined = decline("refined")
-    val requests = "com.lihaoyi" %% "requests" % "0.9.0"
-    val upickle = "com.lihaoyi" %% "upickle" % "3.3.1"
     val catsEffectTestkit = "org.typelevel" %% "cats-effect-testkit" % "3.4.7"
     val scribeJavaCore =  "com.github.scribejava" % "scribejava-core" % "8.3.2"
     val scribeJavaApis =  "com.github.scribejava" % "scribejava-apis" % "8.3.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,12 +21,11 @@ object Dependencies {
     val declineCore = decline()
     val declineEffect = decline("effect")
     val declineRefined = decline("refined")
-    val requests = "com.lihaoyi" %% "requests" % "0.8.0"
-    val upickle = "com.lihaoyi" %% "upickle" % "3.1.3"
+    val requests = "com.lihaoyi" %% "requests" % "0.9.0"
+    val upickle = "com.lihaoyi" %% "upickle" % "3.3.1"
     val catsEffectTestkit = "org.typelevel" %% "cats-effect-testkit" % "3.4.7"
-    val weaverCats = "com.disneystreaming" %% "weaver-cats" % "0.8.1"
-    val weaverDiscipline = "com.disneystreaming" %% "weaver-discipline" % "0.8.1"
-    val weaverScalaCheck = "com.disneystreaming" %% "weaver-scalacheck" % "0.8.1"
+    val scribeJavaCore =  "com.github.scribejava" % "scribejava-core" % "8.3.2"
+    val scribeJavaApis =  "com.github.scribejava" % "scribejava-apis" % "8.3.2"
   }
 
 


### PR DESCRIPTION
### Changes
- Added new data source for X/Twitter
- Added a worker to fetch the information and build the updates for this new data source
-  This new worker will fetch the users that should be queried in Twitter through lattice API. Then we will filter the users exceeding the post daily limit and then query in X/Twitter API for posts with desired text if a user is eligible.
- Added new configuration on the application.conf file to configure this new worker
```json
x-daemon {
  x-api-url = "${X_API_URL}"
  x-api-consumer-key = "${X_API_CONSUMER_KEY}"
  x-api-consumer-secret = "${X_API_CONSUMER_SECRET}"
  x-api-access-token = "${X_API_ACCESS_TOKEN}"
  x-api-access-secret = "${X_API_ACCESS_SECRET}"
  users-source-api-url = "${USERS_SOURCE_API_URL}"
  search-information = ${X_SEARCH_INFORMATION}
  idle-time = ${X_WORKER_INTERVAL}
}

```
+ The Twitter/X integration uses OAUTH 1 authentication since the Bearer token has a known bug:
https://devcommunity.x.com/t/v2-api-unauthorized-401/188899/14

### Tests
- I've tested the flow with a single post per day in configuration and multiple posts per day. I mean,  in search-information  I've provided the following:
```json
  search-information = [
    { text = "$DAG", reward-amount = 3, max-per-day = 3 }
  ]
  and
    search-information = [
    { text = "$DAG", reward-amount = 3, max-per-day = 1 }
  ]
```

and this is the state output
<img width="1335" alt="Captura de Tela 2024-08-01 às 11 48 51" src="https://github.com/user-attachments/assets/e05a4494-a3d5-448b-9bab-250b1f3a8ffd">
<img width="2050" alt="Captura de Tela 2024-08-01 às 11 54 36" src="https://github.com/user-attachments/assets/54c707b4-8ab2-471c-8a70-920efa1c29aa">

and in postman, we can check the rewards were distributed
<img width="1888" alt="Captura de Tela 2024-08-01 às 11 59 59" src="https://github.com/user-attachments/assets/98a921f4-443d-40c9-8f4f-ad5abcdb9b3d">

