### PR TITLE
feat: adding streak data source

### DIFF
--- a/.github/templates/deploy/action.yml
+++ b/.github/templates/deploy/action.yml
@@ -79,6 +79,8 @@ inputs:
     required: true
   X_WORKER_INTERVAL:
     required: true
+  STARGAZER_PUBLIC_KEY:
+    required: true
 runs:
   using: "composite"
   steps:
@@ -135,6 +137,7 @@ runs:
         export USERS_SOURCE_API_URL="${{ inputs.USERS_SOURCE_API_URL }}"
         export X_SEARCH_INFORMATION="${{ inputs.X_SEARCH_INFORMATION }}"
         export X_WORKER_INTERVAL="${{ inputs.X_WORKER_INTERVAL }}"
+        export STARGAZER_PUBLIC_KEY="${{ inputs.STARGAZER_PUBLIC_KEY }}"
 
         cd modules/shared_data/src/main/resources
         envsubst < application.conf > application.conf.tmp

--- a/.github/workflows/deploy-integrationnet.yml
+++ b/.github/workflows/deploy-integrationnet.yml
@@ -48,6 +48,7 @@ jobs:
           USERS_SOURCE_API_URL: ${{secrets.USERS_SOURCE_API_URL}}
           X_SEARCH_INFORMATION: ${{secrets.X_SEARCH_INFORMATION}}
           X_WORKER_INTERVAL: ${{secrets.X_WORKER_INTERVAL}}
+          STARGAZER_PUBLIC_KEY: ${{secrets.STARGAZER_PUBLIC_KEY}}
 
           SSH_NODE_1_HOST: ${{ secrets.SSH_HOST_INTNET_1 }}
           SSH_NODE_1_USER: ${{ secrets.SSH_USER_INTNET_1 }}

--- a/.github/workflows/deploy-mainnet.yml
+++ b/.github/workflows/deploy-mainnet.yml
@@ -48,6 +48,7 @@ jobs:
           USERS_SOURCE_API_URL: ${{secrets.USERS_SOURCE_API_URL}}
           X_SEARCH_INFORMATION: ${{secrets.X_SEARCH_INFORMATION}}
           X_WORKER_INTERVAL: ${{secrets.X_WORKER_INTERVAL}}
+          STARGAZER_PUBLIC_KEY: ${{secrets.STARGAZER_PUBLIC_KEY}}
 
           SSH_NODE_1_HOST: ${{ secrets.SSH_HOST_MAINNET_1 }}
           SSH_NODE_1_USER: ${{ secrets.SSH_USER_MAINNET_1 }}

--- a/README.md
+++ b/README.md
@@ -82,8 +82,32 @@ Additionally, there are manual data sources that require a `DataUpdate` to be se
   ]
 }
 ```
-
 **NOTE: Only one update per wallet will be accepted. If you provide the same wallet again, it will be discarded.**
+
+2. **Claim/Streak:**
+-  **Description:** Stargazer will send daily updates to claim PACA rewards. Wallets can build a streak based on consecutive daily claims:
+      -  **1 to 4 days**: The user receives **1 PACA** per day.
+      -  **5 to 10 days**: The user receives **2 PACA** per day.
+      -  **More than 10 days**: The user receives **5 PACA** per day.
+
+-  **Streak Reset**: If the streak is broken (i.e., the user misses a day), the streak will reset to 1, and the user must start over.
+-  **Expected Update Format**: For streak updates, the following structure should be sent to the metagraph:
+
+```json
+{
+  "value": {
+     "StreakUpdate": {
+        "address": ":address"
+     }
+  },
+  "proofs": [
+    {
+      "id": ":public_key_of_stargazer",
+      "signature": ":signature"
+    }
+  ]
+}
+```
 
 ## Token Minting Rates
 
@@ -94,6 +118,10 @@ Additionally, there are manual data sources that require a `DataUpdate` to be se
 - **Inflow Transactions:** Defined in configuration.
 - **Outflow Transactions:** Defined in configuration.
 - **X/Twitter Posts:** Defined in configuration.
+- **Claim/Streak:**
+  -  **1 to 4 days**: The user receives **1 PACA** per day.
+  -  **5 to 10 days**: The user receives **2 PACA** per day.
+  -  **More than 10 days**: The user receives **5 PACA** per day.
 
 ## Worker/Daemon Functionality
 

--- a/modules/data_l1/src/main/scala/org/elpaca_metagraph/data_l1/DataL1Service.scala
+++ b/modules/data_l1/src/main/scala/org/elpaca_metagraph/data_l1/DataL1Service.scala
@@ -6,6 +6,8 @@ import cats.syntax.all._
 import io.circe.{Decoder, Encoder}
 import org.elpaca_metagraph.shared_data.LifecycleSharedFunctions
 import org.elpaca_metagraph.shared_data.calculated_state.CalculatedStateService
+import org.elpaca_metagraph.shared_data.deserializers.Deserializers
+import org.elpaca_metagraph.shared_data.serializers.Serializers
 import org.elpaca_metagraph.shared_data.types.DataUpdates._
 import org.elpaca_metagraph.shared_data.types.States._
 import org.elpaca_metagraph.shared_data.types.codecs.DataUpdateCodec._
@@ -71,32 +73,32 @@ object DataL1Service {
       override def serializeBlock(
         block: Signed[DataApplicationBlock]
       ): F[Array[Byte]] =
-        JsonSerializer[F].serialize[Signed[DataApplicationBlock]](block)
+        Serializers.serializeBlock(block)
 
       override def deserializeBlock(
         bytes: Array[Byte]
       ): F[Either[Throwable, Signed[DataApplicationBlock]]] =
-        JsonSerializer[F].deserialize[Signed[DataApplicationBlock]](bytes)
+        Deserializers.deserializeBlock(bytes)
 
       override def serializeState(
         state: ElpacaOnChainState
       ): F[Array[Byte]] =
-        JsonSerializer[F].serialize[ElpacaOnChainState](state)
+        Serializers.serializeState(state)
 
       override def deserializeState(
         bytes: Array[Byte]
       ): F[Either[Throwable, ElpacaOnChainState]] =
-        JsonSerializer[F].deserialize[ElpacaOnChainState](bytes)
+        Deserializers.deserializeState(bytes)
 
       override def serializeUpdate(
         update: ElpacaUpdate
       ): F[Array[Byte]] =
-        JsonSerializer[F].serialize[ElpacaUpdate](update)
+        Serializers.serializeUpdate(update)
 
       override def deserializeUpdate(
         bytes: Array[Byte]
       ): F[Either[Throwable, ElpacaUpdate]] =
-        JsonSerializer[F].deserialize[ElpacaUpdate](bytes)
+        Deserializers.deserializeUpdate(bytes)
 
       override def getCalculatedState(implicit context: L1NodeContext[F]): F[(SnapshotOrdinal, ElpacaCalculatedState)] =
         calculatedStateService.get.map(calculatedState => (calculatedState.ordinal, calculatedState.state))
@@ -115,12 +117,12 @@ object DataL1Service {
       override def serializeCalculatedState(
         state: ElpacaCalculatedState
       ): F[Array[Byte]] =
-        JsonSerializer[F].serialize[ElpacaCalculatedState](state)
+        Serializers.serializeCalculatedState(state)
 
       override def deserializeCalculatedState(
         bytes: Array[Byte]
       ): F[Either[Throwable, ElpacaCalculatedState]] =
-        JsonSerializer[F].deserialize[ElpacaCalculatedState](bytes)
+        Deserializers.deserializeCalculatedState(bytes)
     }
   )
 }

--- a/modules/l0/src/main/scala/org/elpaca_metagraph/l0/MetagraphL0Service.scala
+++ b/modules/l0/src/main/scala/org/elpaca_metagraph/l0/MetagraphL0Service.scala
@@ -12,6 +12,8 @@ import org.elpaca_metagraph.shared_data.LifecycleSharedFunctions
 import org.elpaca_metagraph.shared_data.Utils.toTokenAmountFormat
 import org.elpaca_metagraph.shared_data.app.ApplicationConfig
 import org.elpaca_metagraph.shared_data.calculated_state.CalculatedStateService
+import org.elpaca_metagraph.shared_data.deserializers.Deserializers
+import org.elpaca_metagraph.shared_data.serializers.Serializers
 import org.elpaca_metagraph.shared_data.types.DataUpdates._
 import org.elpaca_metagraph.shared_data.types.ExistingWallets.ExistingWalletsDataSourceAddress
 import org.elpaca_metagraph.shared_data.types.FreshWallet.FreshWalletDataSourceAddress
@@ -104,7 +106,7 @@ object MetagraphL0Service {
           state  : DataState[ElpacaOnChainState, ElpacaCalculatedState],
           updates: NonEmptyList[Signed[ElpacaUpdate]]
         )(implicit context: L0NodeContext[F]): F[DataApplicationValidationErrorOr[Unit]] =
-          valid.pure
+          LifecycleSharedFunctions.validateData(updates, state, applicationConfig)
 
         override def combine(
           state  : DataState[ElpacaOnChainState, ElpacaCalculatedState],
@@ -133,33 +135,34 @@ object MetagraphL0Service {
 
         override def serializeBlock(
           block: Signed[DataApplicationBlock]
-        ): F[Array[Byte]] =
-          JsonSerializer[F].serialize[Signed[DataApplicationBlock]](block)
+        ): F[Array[Byte]] = {
+          Serializers.serializeBlock(block)
+        }
 
         override def deserializeBlock(
           bytes: Array[Byte]
         ): F[Either[Throwable, Signed[DataApplicationBlock]]] =
-          JsonSerializer[F].deserialize[Signed[DataApplicationBlock]](bytes)
+          Deserializers.deserializeBlock(bytes)
 
         override def serializeState(
           state: ElpacaOnChainState
         ): F[Array[Byte]] =
-          JsonSerializer[F].serialize[ElpacaOnChainState](state)
+          Serializers.serializeState(state)
 
         override def deserializeState(
           bytes: Array[Byte]
         ): F[Either[Throwable, ElpacaOnChainState]] =
-          JsonSerializer[F].deserialize[ElpacaOnChainState](bytes)
+          Deserializers.deserializeState(bytes)
 
         override def serializeUpdate(
           update: ElpacaUpdate
         ): F[Array[Byte]] =
-          JsonSerializer[F].serialize[ElpacaUpdate](update)
+          Serializers.serializeUpdate(update)
 
         override def deserializeUpdate(
           bytes: Array[Byte]
         ): F[Either[Throwable, ElpacaUpdate]] =
-          JsonSerializer[F].deserialize[ElpacaUpdate](bytes)
+          Deserializers.deserializeUpdate(bytes)
 
         override def getCalculatedState(implicit context: L0NodeContext[F]): F[(SnapshotOrdinal, ElpacaCalculatedState)] =
           calculatedStateService.get.map(calculatedState => (calculatedState.ordinal, calculatedState.state))
@@ -181,11 +184,11 @@ object MetagraphL0Service {
         override def serializeCalculatedState(
           state: ElpacaCalculatedState
         ): F[Array[Byte]] =
-          JsonSerializer[F].serialize[ElpacaCalculatedState](state)
+          Serializers.serializeCalculatedState(state)
 
         override def deserializeCalculatedState(
           bytes: Array[Byte]
         ): F[Either[Throwable, ElpacaCalculatedState]] =
-          JsonSerializer[F].deserialize[ElpacaCalculatedState](bytes)
+          Deserializers.deserializeCalculatedState(bytes)
       })
 }

--- a/modules/l0/src/main/scala/org/elpaca_metagraph/l0/custom_routes/CustomRoutes.scala
+++ b/modules/l0/src/main/scala/org/elpaca_metagraph/l0/custom_routes/CustomRoutes.scala
@@ -5,16 +5,28 @@ import cats.syntax.all._
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
 import eu.timepit.refined.auto._
+import eu.timepit.refined.types.numeric.NonNegLong
+import org.elpaca_metagraph.shared_data.Utils.getCurrentEpochProgress
 import org.elpaca_metagraph.shared_data.calculated_state.CalculatedStateService
 import org.elpaca_metagraph.shared_data.types.States.DataSourceType._
-import org.elpaca_metagraph.shared_data.types.States.ElpacaCalculatedState
+import org.elpaca_metagraph.shared_data.types.States.{ElpacaCalculatedState, StreakDataSource}
+import org.elpaca_metagraph.shared_data.types.codecs.NonNegLongCodec._
 import org.http4s.circe.CirceEntityCodec.circeEntityEncoder
 import org.http4s.dsl.Http4sDsl
 import org.http4s.server.middleware.CORS
 import org.http4s.{HttpRoutes, Response}
+import org.tessellation.currency.dataApplication.L0NodeContext
+import org.tessellation.ext.http4s.AddressVar
 import org.tessellation.routes.internal.{InternalUrlPrefix, PublicRoutes}
+import org.tessellation.schema.address.Address
+import org.tessellation.schema.balance.Amount
+import org.tessellation.schema.epoch.EpochProgress
 
-case class CustomRoutes[F[_] : Async](calculatedStateService: CalculatedStateService[F]) extends Http4sDsl[F] with PublicRoutes[F] {
+case class CustomRoutes[F[_] : Async](
+  calculatedStateService: CalculatedStateService[F]
+)(
+  implicit context: L0NodeContext[F]
+) extends Http4sDsl[F] with PublicRoutes[F] {
 
   @derive(encoder, decoder)
   case class CalculatedStateResponse(
@@ -38,7 +50,8 @@ case class CustomRoutes[F[_] : Async](calculatedStateService: CalculatedStateSer
       "existingwallets" -> ExistingWallets,
       "inflowtransactions" -> InflowTransactions,
       "outflowtransactions" -> OutflowTransactions,
-      "x" -> X
+      "x" -> X,
+      "streak" -> Streak
     )
 
     calculatedStateService
@@ -50,12 +63,49 @@ case class CustomRoutes[F[_] : Async](calculatedStateService: CalculatedStateSer
           .map(Ok(_))
           .getOrElse(NotFound())
       }
+  }
+
+  private def getAddressStreakInformation(address: Address): F[Response[F]] = {
+    @derive(encoder, decoder)
+    case class AddressStreakInformation(
+      currentStreak         : NonNegLong,
+      totalEarned           : Amount,
+      claimAmount           : Amount,
+      lastClaimEpochProgress: EpochProgress,
+      currentEpochProgress  : EpochProgress
+    )
+
+    for {
+      epochProgress <- getCurrentEpochProgress
+      response <- calculatedStateService
+        .get
+        .flatMap { state =>
+          state.state.dataSources
+            .get(Streak)
+            .collect { case ds: StreakDataSource => ds }
+            .getOrElse(StreakDataSource(Map.empty))
+            .existingWallets
+            .get(address).map { addressInfo =>
+              Ok(
+                AddressStreakInformation(
+                  addressInfo.streakDays,
+                  addressInfo.totalEarned,
+                  addressInfo.nextClaimReward,
+                  addressInfo.epochProgressToReward,
+                  epochProgress
+                )
+              )
+            }
+            .getOrElse(NotFound())
+        }
+    } yield response
 
   }
 
   private val routes: HttpRoutes[F] = HttpRoutes.of[F] {
     case GET -> Root / "calculated-state" => getLatestCalculatedState
     case GET -> Root / "calculated-state" / dataSourceName => getCalculatedStateByDataSource(dataSourceName)
+    case GET -> Root / "streak" / AddressVar(address) => getAddressStreakInformation(address)
   }
 
   val public: HttpRoutes[F] =

--- a/modules/l0/src/main/scala/org/elpaca_metagraph/l0/rewards/ElpacaRewards.scala
+++ b/modules/l0/src/main/scala/org/elpaca_metagraph/l0/rewards/ElpacaRewards.scala
@@ -102,6 +102,10 @@ object ElpacaRewards {
               }
             }
 
+          case dataSource: StreakDataSource =>
+            dataSource.existingWallets.collect {
+              case (address, ds) if ds.epochProgressToReward === currentEpochProgress => address -> ds.amountToReward
+            }
           case _ => Map.empty[Address, Amount]
         }
       }
@@ -111,7 +115,7 @@ object ElpacaRewards {
         currentEpochProgress            : EpochProgress
       ): F[SortedSet[RewardTransaction]] = for {
         _ <- logger.info("Starting to build the rewards")
-        combinedAddressesAndAmounts = Seq(Exolix, Simplex, IntegrationnetNodeOperator, WalletCreationHoldingDAG, FreshWallet, InflowTransactions, OutflowTransactions, X)
+        combinedAddressesAndAmounts = Seq(Exolix, Simplex, IntegrationnetNodeOperator, WalletCreationHoldingDAG, FreshWallet, InflowTransactions, OutflowTransactions, X, Streak)
           .flatMap(getAddressAndAmounts(proofOfAttendanceCalculatedState, currentEpochProgress, _))
           .groupBy(_._1)
           .view

--- a/modules/shared_data/src/main/resources/application.conf
+++ b/modules/shared_data/src/main/resources/application.conf
@@ -56,6 +56,11 @@ x-daemon {
   idle-time = ${X_WORKER_INTERVAL}
 }
 
+streak {
+ stargazer-public-key = "${STARGAZER_PUBLIC_KEY}"
+}
+
+
 node-key {
   keystore = CL_KEYSTORE_PLACEHOLDER
   alias = CL_KEYALIAS_PLACEHOLDER

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/app/ApplicationConfig.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/app/ApplicationConfig.scala
@@ -4,6 +4,7 @@ import ciris.Secret
 import fs2.io.file.Path
 import org.elpaca_metagraph.shared_data.types.Refined.ApiUrl
 import org.tessellation.node.shared.config.types.HttpClientConfig
+import org.tessellation.schema.ID.Id
 import org.tessellation.schema.address.Address
 import org.tessellation.schema.balance.Amount
 
@@ -20,7 +21,8 @@ case class ApplicationConfig(
   inflowTransactionsDaemon          : ApplicationConfig.InflowTransactionsDaemonConfig,
   outflowTransactionsDaemon         : ApplicationConfig.OutflowTransactionsDaemonConfig,
   nodeKey                           : ApplicationConfig.NodeKey,
-  xDaemon                           : ApplicationConfig.XDaemonConfig
+  xDaemon                           : ApplicationConfig.XDaemonConfig,
+  streak                            : ApplicationConfig.StreakConfig
 )
 
 object ApplicationConfig {
@@ -91,6 +93,10 @@ object ApplicationConfig {
     xApiAccessToken   : Option[String],
     xApiAccessSecret  : Option[String],
     searchInformation : List[XSearchInfo]
+  )
+
+  case class StreakConfig(
+    stargazerPublicKey: Id
   )
 
   case class NodeKey(

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/app/ApplicationConfigOps.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/app/ApplicationConfigOps.scala
@@ -8,8 +8,10 @@ import eu.timepit.refined.types.numeric.NonNegLong
 import fs2.io.file.Path
 import org.elpaca_metagraph.shared_data.types.Refined.ApiUrl
 import org.tessellation.node.shared.config.types.HttpClientConfig
+import org.tessellation.schema.ID.Id
 import org.tessellation.schema.address.{Address, DAGAddressRefined}
 import org.tessellation.schema.balance.Amount
+import org.tessellation.security.hex.Hex
 import pureconfig._
 import pureconfig.error.CannotConvert
 import pureconfig.generic.semiauto.deriveReader
@@ -37,6 +39,8 @@ object ConfigReaders {
   implicit val portReader: ConfigReader[Port] =
     ConfigReader[Int].emap(i => Port.fromInt(i).toRight(CannotConvert(i.toString, "Port", "Parse resulted in None")))
 
+  implicit val idReader: ConfigReader[Id] = ConfigReader[String].emap(s => Option(Id(Hex(s))).toRight(CannotConvert(s, "Id", "Parse resulted in None")))
+
   implicit val amountReader: ConfigReader[Amount] = {
     import eu.timepit.refined.pureconfig._
     ConfigReader[NonNegLong].map(Amount(_))
@@ -58,6 +62,7 @@ object ConfigReaders {
   implicit val outflowTransactionsDaemonConfigReader: ConfigReader[ApplicationConfig.OutflowTransactionsDaemonConfig] = deriveReader
   implicit val xSearchInfoReader: ConfigReader[ApplicationConfig.XSearchInfo] = deriveReader
   implicit val xDaemonConfigReader: ConfigReader[ApplicationConfig.XDaemonConfig] = deriveReader
+  implicit val streakConfigReader: ConfigReader[ApplicationConfig.StreakConfig] = deriveReader
   implicit val nodeKeyReader: ConfigReader[ApplicationConfig.NodeKey] = deriveReader
   implicit val clientConfigReader: ConfigReader[HttpClientConfig] = deriveReader
   implicit val http4sConfigReader: ConfigReader[ApplicationConfig.Http4sConfig] = deriveReader

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/combiners/Combiner.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/combiners/Combiner.scala
@@ -9,6 +9,7 @@ import org.elpaca_metagraph.shared_data.combiners.InflowTransactionsCombiner.upd
 import org.elpaca_metagraph.shared_data.combiners.IntegrationnetOperatorsCombiner.updateStateIntegrationnetOperatorsResponse
 import org.elpaca_metagraph.shared_data.combiners.OutflowTransactionsCombiner.updateStateOutflowTransactions
 import org.elpaca_metagraph.shared_data.combiners.SimplexCombiner.updateStateSimplexResponse
+import org.elpaca_metagraph.shared_data.combiners.StreakCombiner.updateStateStreak
 import org.elpaca_metagraph.shared_data.combiners.WalletCreationHoldingDAGCombiner.updateStateWalletCreationHoldingDAG
 import org.elpaca_metagraph.shared_data.combiners.XCombiner.updateStateX
 import org.elpaca_metagraph.shared_data.types.DataUpdates._
@@ -104,6 +105,18 @@ object Combiner {
         ).asInstanceOf[DataSource]
 
         (DataSourceType.X, updatedXDataSource.pure)
+
+      case streakUpdate: StreakUpdate =>
+        implicit val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromName[F]("StreakCombiner")
+        val updatedStreakDataSource = updateStateStreak(
+          currentDataSources,
+          currentEpochProgress,
+          streakUpdate,
+          update.proofs,
+          applicationConfig
+        ).map(_.asInstanceOf[DataSource])
+
+        (DataSourceType.Streak, updatedStreakDataSource)
     }
     updatedDataSourceF.map { updatedDataSource =>
       val updates: List[ElpacaUpdate] = update.value :: oldState.onChain.updates

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/combiners/StreakCombiner.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/combiners/StreakCombiner.scala
@@ -1,0 +1,114 @@
+package org.elpaca_metagraph.shared_data.combiners
+
+import cats.data.NonEmptySet
+import cats.effect.Async
+import cats.implicits.toFunctorOps
+import eu.timepit.refined.types.numeric.NonNegLong
+import monocle.Monocle.toAppliedFocusOps
+import org.elpaca_metagraph.shared_data.Utils._
+import org.elpaca_metagraph.shared_data.app.ApplicationConfig
+import org.elpaca_metagraph.shared_data.types.DataUpdates._
+import org.elpaca_metagraph.shared_data.types.States._
+import org.elpaca_metagraph.shared_data.types.Streak.StreakDataSourceAddress
+import org.tessellation.schema.balance.Amount
+import org.tessellation.schema.epoch.EpochProgress
+import org.tessellation.security.signature.signature.SignatureProof
+import org.typelevel.log4cats.Logger
+
+object StreakCombiner {
+  private val level1Streak = NonNegLong(1L)
+  private val level2Streak = NonNegLong(3L)
+  private val level3Streak = NonNegLong(5L)
+
+  private def getCurrentStreakDataSource(
+    currentCalculatedState: Map[DataSourceType, DataSource]
+  ): StreakDataSource = {
+    currentCalculatedState
+      .get(DataSourceType.Streak) match {
+      case Some(streakDataSource: StreakDataSource) => streakDataSource
+      case _ => StreakDataSource(Map.empty)
+    }
+  }
+
+  def updateStateStreak[F[_] : Async : Logger](
+    currentCalculatedState: Map[DataSourceType, DataSource],
+    currentEpochProgress  : EpochProgress,
+    streakUpdate          : StreakUpdate,
+    proofs                : NonEmptySet[SignatureProof],
+    applicationConfig     : ApplicationConfig
+  ): F[StreakDataSource] = {
+    val streakDataSource = getCurrentStreakDataSource(currentCalculatedState)
+    val isSignedByStargazer = walletSignedTheMessage(applicationConfig.streak.stargazerPublicKey, proofs)
+    if (!isSignedByStargazer) {
+      Logger[F].warn(s"The update $streakUpdate was not signed by stargazer, ignoring").as(
+        streakDataSource
+      )
+    } else {
+      case class StreakInfo(streakDays: NonNegLong, rewardAmount: Amount)
+
+      val streakDataSourceAddress = streakDataSource.existingWallets
+        .get(streakUpdate.address) match {
+        case Some(streakDataSourceAddress) => streakDataSourceAddress
+        case None => StreakDataSourceAddress.empty
+      }
+
+      if (!isNewDay(streakDataSourceAddress.epochProgressToReward, currentEpochProgress)) {
+        Logger[F].info(s"This address already claimed reward of the day, ignoring").as(
+          streakDataSource
+        )
+      } else {
+        def shouldResetStreak: Boolean =
+          currentEpochProgress.value.value - streakDataSourceAddress.epochProgressToReward.value.value > epochProgressOneDay
+
+        def streakBetween(min: Long, max: Long, updatedStreakDays: NonNegLong): Boolean =
+          updatedStreakDays.value >= min && updatedStreakDays.value <= max
+
+        def calculateRewardAmount(streakDays: NonNegLong): Amount = {
+          if (streakBetween(1L, 4L, streakDays)) Amount(level1Streak)
+          else if (streakBetween(5L, 10L, streakDays)) Amount(level2Streak)
+          else Amount(level3Streak)
+        }
+
+        def getUpdateStreakInfo(streakDays: NonNegLong): StreakInfo = {
+          if (shouldResetStreak) {
+            StreakInfo(level1Streak, toTokenAmountFormat(Amount(level1Streak)))
+          } else {
+            val updatedStreakDays = NonNegLong.unsafeFrom(streakDays.value + 1L)
+            val rewardAmount = toTokenAmountFormat(calculateRewardAmount(updatedStreakDays))
+            StreakInfo(updatedStreakDays, rewardAmount)
+          }
+        }
+
+        def updateStreakDataSource(streakInfo: StreakInfo, nextStreakInfo: StreakInfo): StreakDataSourceAddress = {
+          val totalEarned = Amount(
+            NonNegLong.unsafeFrom(streakDataSourceAddress.totalEarned.value.value + streakInfo.rewardAmount.value.value)
+          )
+
+          streakDataSourceAddress
+            .focus(_.dailyEpochProgress)
+            .replace(currentEpochProgress)
+            .focus(_.epochProgressToReward)
+            .replace(currentEpochProgress)
+            .focus(_.amountToReward)
+            .replace(streakInfo.rewardAmount)
+            .focus(_.totalEarned)
+            .replace(totalEarned)
+            .focus(_.nextClaimReward)
+            .replace(nextStreakInfo.rewardAmount)
+            .focus(_.streakDays)
+            .replace(streakInfo.streakDays)
+        }
+
+        val currentStreakInfo = getUpdateStreakInfo(streakDataSourceAddress.streakDays)
+        val nextStreakInfo = getUpdateStreakInfo(currentStreakInfo.streakDays)
+        val updatedDataSourceAddress = updateStreakDataSource(currentStreakInfo, nextStreakInfo)
+
+        Logger[F].info(s"Claiming reward of the address ${streakUpdate.address}. Streak: ${currentStreakInfo.streakDays}").as(
+          streakDataSource
+            .focus(_.existingWallets)
+            .modify(_.updated(streakUpdate.address, updatedDataSourceAddress))
+        )
+      }
+    }
+  }
+}

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/combiners/XCombiner.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/combiners/XCombiner.scala
@@ -2,7 +2,7 @@ package org.elpaca_metagraph.shared_data.combiners
 
 import cats.syntax.all._
 import monocle.Monocle.toAppliedFocusOps
-import org.elpaca_metagraph.shared_data.Utils.{epochProgressOneDay, toTokenAmountFormat}
+import org.elpaca_metagraph.shared_data.Utils._
 import org.elpaca_metagraph.shared_data.app.ApplicationConfig
 import org.elpaca_metagraph.shared_data.types.DataUpdates._
 import org.elpaca_metagraph.shared_data.types.States._
@@ -88,8 +88,6 @@ object XCombiner {
       val updatedData = xDataSourceAddress.addressRewards
         .get(xUpdate.searchText)
         .map { data =>
-          def isNewDay = data.epochProgressToReward.value.value + epochProgressOneDay < currentEpochProgress.value.value
-
           def updateXRewardInfoNewDay() = {
             data
               .focus(_.dailyEpochProgress)
@@ -105,6 +103,7 @@ object XCombiner {
           }
 
           def isNotExceedingDailyLimit = data.dailyPostsNumber < searchInformation.maxPerDay
+
           def postAlreadyExists = data.postIds.contains(xUpdate.postId)
 
           def updateXRewardInfoSameDay() = {
@@ -128,7 +127,7 @@ object XCombiner {
             }
           }
 
-          if (isNewDay) {
+          if (isNewDay(data.epochProgressToReward, currentEpochProgress)) {
             updateXRewardInfoNewDay()
           } else if (isNotExceedingDailyLimit && !postAlreadyExists) {
             updateXRewardInfoSameDay()

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/deserializers/Deserializers.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/deserializers/Deserializers.scala
@@ -1,0 +1,37 @@
+package org.elpaca_metagraph.shared_data.deserializers
+
+import io.circe.Decoder
+import org.elpaca_metagraph.shared_data.types.DataUpdates.ElpacaUpdate
+import org.elpaca_metagraph.shared_data.types.States.{ElpacaCalculatedState, ElpacaOnChainState}
+import org.tessellation.currency.dataApplication.DataUpdate
+import org.tessellation.currency.dataApplication.dataApplication.DataApplicationBlock
+import org.tessellation.json.JsonSerializer
+import org.tessellation.security.signature.Signed
+
+object Deserializers {
+  private def deserialize[F[_] : JsonSerializer, A: Decoder](
+    bytes: Array[Byte]
+  ): F[Either[Throwable, A]] = {
+    JsonSerializer[F].deserialize[A](bytes)
+  }
+
+  def deserializeUpdate[F[_] : JsonSerializer](
+    bytes: Array[Byte]
+  ): F[Either[Throwable, ElpacaUpdate]] =
+    deserialize[F, ElpacaUpdate](bytes)
+
+  def deserializeState[F[_] : JsonSerializer](
+    bytes: Array[Byte]
+  ): F[Either[Throwable, ElpacaOnChainState]] =
+    deserialize[F, ElpacaOnChainState](bytes)
+
+  def deserializeBlock[F[_] : JsonSerializer](
+    bytes: Array[Byte]
+  )(implicit e: Decoder[DataUpdate]): F[Either[Throwable, Signed[DataApplicationBlock]]] =
+    deserialize[F, Signed[DataApplicationBlock]](bytes)
+
+  def deserializeCalculatedState[F[_] : JsonSerializer](
+    bytes: Array[Byte]
+  ): F[Either[Throwable, ElpacaCalculatedState]] =
+    deserialize[F, ElpacaCalculatedState](bytes)
+}

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/serializers/Serializers.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/serializers/Serializers.scala
@@ -1,0 +1,54 @@
+package org.elpaca_metagraph.shared_data.serializers
+
+import cats.effect.Async
+import io.circe.Encoder
+import io.circe.syntax.EncoderOps
+import org.elpaca_metagraph.shared_data.types.DataUpdates.{ElpacaUpdate, StreakUpdate}
+import org.elpaca_metagraph.shared_data.types.States.{ElpacaCalculatedState, ElpacaOnChainState}
+import org.tessellation.currency.dataApplication.DataUpdate
+import org.tessellation.currency.dataApplication.dataApplication.DataApplicationBlock
+import org.tessellation.json.JsonSerializer
+import org.tessellation.security.signature.Signed
+
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+
+object Serializers {
+  private def serialize[F[_] : JsonSerializer, A: Encoder](
+    serializableData: A
+  ): F[Array[Byte]] = {
+    JsonSerializer[F].serialize[A](serializableData)
+  }
+
+  def serializeUpdate[F[_] : Async : JsonSerializer](
+    update: ElpacaUpdate
+  ): F[Array[Byte]] =
+    update match {
+      case _: StreakUpdate =>
+        Async[F].delay {
+          val dataSignPrefix = "\u0019Constellation Signed Data:\n"
+          val encodedString = Base64.getEncoder.encodeToString(update.asJson.deepDropNullValues.noSpaces.getBytes(StandardCharsets.UTF_8))
+          val completeString = s"$dataSignPrefix${encodedString.length}\n$encodedString"
+
+          completeString.getBytes(StandardCharsets.UTF_8)
+        }
+      case _ =>
+        serialize[F, ElpacaUpdate](update)
+    }
+
+
+  def serializeState[F[_] : JsonSerializer](
+    state: ElpacaOnChainState
+  ): F[Array[Byte]] =
+    serialize[F, ElpacaOnChainState](state)
+
+  def serializeBlock[F[_] : JsonSerializer](
+    state: Signed[DataApplicationBlock]
+  )(implicit e: Encoder[DataUpdate]): F[Array[Byte]] =
+    serialize[F, Signed[DataApplicationBlock]](state)
+
+  def serializeCalculatedState[F[_] : JsonSerializer](
+    state: ElpacaCalculatedState
+  ): F[Array[Byte]] =
+    serialize[F, ElpacaCalculatedState](state)
+}

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/DataUpdates.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/DataUpdates.scala
@@ -67,4 +67,9 @@ object DataUpdates {
     searchText: String,
     postId    : String
   ) extends ElpacaUpdate
+
+  @derive(encoder, decoder)
+  case class StreakUpdate(
+    address   : Address
+  ) extends ElpacaUpdate
 }

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/States.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/States.scala
@@ -13,6 +13,7 @@ import org.elpaca_metagraph.shared_data.types.InflowTransactions.InflowTransacti
 import org.elpaca_metagraph.shared_data.types.IntegrationnetOperators.IntegrationnetNodeOperatorDataSourceAddress
 import org.elpaca_metagraph.shared_data.types.OutflowTransactions.OutflowTransactionsDataSourceAddress
 import org.elpaca_metagraph.shared_data.types.Simplex.SimplexDataSourceAddress
+import org.elpaca_metagraph.shared_data.types.Streak.StreakDataSourceAddress
 import org.elpaca_metagraph.shared_data.types.WalletCreationHoldingDAG.WalletCreationHoldingDAGDataSourceAddress
 import org.elpaca_metagraph.shared_data.types.X.XDataSourceAddress
 import org.tessellation.currency.dataApplication.{DataCalculatedState, DataOnChainState}
@@ -44,6 +45,8 @@ object States {
     case object OutflowTransactions extends DataSourceType("OutflowTransactions")
 
     case object X extends DataSourceType("X")
+
+    case object Streak extends DataSourceType("Streak")
   }
 
   @derive(encoder, decoder)
@@ -92,6 +95,11 @@ object States {
   @derive(encoder, decoder)
   case class XDataSource(
     existingWallets: Map[Address, XDataSourceAddress]
+  ) extends DataSource
+
+  @derive(encoder, decoder)
+  case class StreakDataSource(
+    existingWallets: Map[Address, StreakDataSourceAddress]
   ) extends DataSource
 
   @derive(encoder, decoder)

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/Streak.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/Streak.scala
@@ -1,0 +1,31 @@
+package org.elpaca_metagraph.shared_data.types
+
+import derevo.circe.magnolia.{decoder, encoder}
+import derevo.derive
+import eu.timepit.refined.types.numeric.NonNegLong
+import org.elpaca_metagraph.shared_data.types.codecs.NonNegLongCodec._
+import org.tessellation.schema.balance.Amount
+import org.tessellation.schema.epoch.EpochProgress
+
+object Streak {
+  @derive(encoder, decoder)
+  case class StreakDataSourceAddress(
+    dailyEpochProgress   : EpochProgress,
+    epochProgressToReward: EpochProgress,
+    amountToReward       : Amount,
+    totalEarned          : Amount,
+    nextClaimReward      : Amount,
+    streakDays           : NonNegLong
+  )
+
+  object StreakDataSourceAddress {
+    def empty: StreakDataSourceAddress = StreakDataSourceAddress(
+      EpochProgress.MinValue,
+      EpochProgress.MinValue,
+      Amount.empty,
+      Amount.empty,
+      Amount.empty,
+      NonNegLong.MinValue
+    )
+  }
+}

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/codecs/NonNegLongCodec.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/codecs/NonNegLongCodec.scala
@@ -1,0 +1,11 @@
+package org.elpaca_metagraph.shared_data.types.codecs
+
+import eu.timepit.refined.numeric.NonNegative
+import eu.timepit.refined.refineV
+import eu.timepit.refined.types.numeric.NonNegLong
+import io.circe.{Decoder, Encoder}
+
+object NonNegLongCodec {
+  implicit val nonNegLongEncoder: Encoder[NonNegLong] = Encoder[Long].contramap(_.value)
+  implicit val nonNegLongDecoder: Decoder[NonNegLong] = Decoder[Long].emap(refineV[NonNegative](_))
+}

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/validations/Errors.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/validations/Errors.scala
@@ -20,4 +20,10 @@ object Errors {
   case object IntegrationnetNodeOperatorBalanceLessThan250K extends DataApplicationValidationError {
     val message = "Integrationnet node operator should have more than 250K DAG"
   }
+  case object StreakUpdateNotSignedByStargazer extends DataApplicationValidationError {
+    val message = "Streak update not signed by Stargazer"
+  }
+  case object StreakAddressAlreadyRewarded extends DataApplicationValidationError {
+    val message = "Streak address already rewarded"
+  }
 }

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/validations/Validations.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/validations/Validations.scala
@@ -1,12 +1,36 @@
 package org.elpaca_metagraph.shared_data.validations
 
-import org.elpaca_metagraph.shared_data.types.DataUpdates.IntegrationnetNodeOperatorUpdate
-import org.elpaca_metagraph.shared_data.validations.TypeValidators.validateIfIntegrationnetOperatorHave250KDAG
+import cats.syntax.all._
+import org.elpaca_metagraph.shared_data.app.ApplicationConfig
+import org.elpaca_metagraph.shared_data.types.DataUpdates.{IntegrationnetNodeOperatorUpdate, StreakUpdate}
+import org.elpaca_metagraph.shared_data.types.States.DataSourceType.Streak
+import org.elpaca_metagraph.shared_data.types.States.{ElpacaCalculatedState, ElpacaOnChainState, StreakDataSource}
+import org.elpaca_metagraph.shared_data.validations.TypeValidators.{validateIfAddressAlreadyRewardedInCurrentDay, validateIfIntegrationnetOperatorHave250KDAG, validateIfUpdateWasSignedByStargazer}
+import org.tessellation.currency.dataApplication.DataState
 import org.tessellation.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
+import org.tessellation.schema.epoch.EpochProgress
+import org.tessellation.security.signature.Signed
 
 object Validations {
   def integrationnetNodeOperatorsValidationsL1(
     integrationnetNodeOpUpdate: IntegrationnetNodeOperatorUpdate
   ): DataApplicationValidationErrorOr[Unit] =
     validateIfIntegrationnetOperatorHave250KDAG(integrationnetNodeOpUpdate)
+
+  def streakValidationsL0(
+    streakUpdate        : Signed[StreakUpdate],
+    oldState            : DataState[ElpacaOnChainState, ElpacaCalculatedState],
+    appConfig           : ApplicationConfig,
+    currentEpochProgress: EpochProgress
+  ): DataApplicationValidationErrorOr[Unit] = {
+    val streakDataSource = oldState.calculated.dataSources
+      .get(Streak)
+      .collect { case ds: StreakDataSource => ds }
+      .getOrElse(StreakDataSource(Map.empty))
+
+    validateIfUpdateWasSignedByStargazer(streakUpdate.proofs, appConfig).productR(
+      validateIfAddressAlreadyRewardedInCurrentDay(streakUpdate.value, streakDataSource, currentEpochProgress)
+    )
+
+  }
 }


### PR DESCRIPTION
### Changes
+ Adding the new datasource of Streak
+ We will accept updates incoming only from stargazer
-  **Description:** Stargazer will send daily updates to claim PACA rewards. Wallets can build a streak based on consecutive daily claims:
      -  **1 to 4 days**: The user receives **1 PACA** per day.
      -  **5 to 10 days**: The user receives **2 PACA** per day.
      -  **More than 10 days**: The user receives **5 PACA** per day.

-  **Streak Reset**: If the streak is broken (i.e., the user misses a day), the streak will reset to 1, and the user must start over.
-  **Expected Update Format**: For streak updates, the following structure should be sent to the metagraph:

```json
{
  "value": {
     "StreakUpdate": {
        "address": ":address"
     }
  },
  "proofs": [
    {
      "id": ":public_key_of_stargazer",
      "signature": ":signature"
    }
  ]
}
```
