### PR TITLE
Adding support for multiple search terms on X and YouTube rewards

### DIFF
--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/XFetcher.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/XFetcher.scala
@@ -123,11 +123,14 @@ object XFetcher {
           maybePostId      : Option[String]
         ): Boolean =
           xDataSource.existingWallets.get(address).fold(true) { existingWallet =>
-            searchInformation.exists { searchInfo =>
-              existingWallet.addressRewards.get(searchInfo.text).fold(true) { addressRewards =>
-                addressRewards.dailyPostsNumber < searchInfo.maxPerDay &&
-                  maybePostId.forall(!addressRewards.postIds.contains(_))
+            val postIdNotUsedInAnySearchInfo = maybePostId.forall { postId =>
+              searchInformation.forall { searchInfo =>
+                existingWallet.addressRewards.get(searchInfo.text).forall(!_.postIds.contains(postId))
               }
+            }
+
+            postIdNotUsedInAnySearchInfo && searchInformation.exists { searchInfo =>
+              existingWallet.addressRewards.get(searchInfo.text).fold(true)(_.dailyPostsNumber < searchInfo.maxPerDay)
             }
           }
 

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/YouTubeFetcher.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/YouTubeFetcher.scala
@@ -195,10 +195,17 @@ object YouTubeFetcher {
     maybeVideo: Option[VideoDetails]
   ): Boolean =
     dataSource.existingWallets.get(address).fold(true) { existingWallet =>
-      searchInformation.exists { searchInfo =>
+      val videoNotUsedInAnySearchInfo = maybeVideo.forall { video =>
+        searchInformation.forall { searchInfo =>
+          existingWallet.addressRewards.get(searchInfo.text).forall { addressRewards =>
+            !addressRewards.videos.contains(video)
+          }
+        }
+      }
+
+      videoNotUsedInAnySearchInfo && searchInformation.exists { searchInfo =>
         existingWallet.addressRewards.get(searchInfo.text).fold(true) { addressRewards =>
-          addressRewards.dailyPostsNumber < searchInfo.maxPerDay &&
-            maybeVideo.forall(!addressRewards.videos.contains(_))
+          addressRewards.dailyPostsNumber < searchInfo.maxPerDay
         }
       }
     }


### PR DESCRIPTION
This pull request changes the way X and YouTube fetchers validate duplicate posts to be rewarded, avoiding paying rewards more than once for the same post or video.