### PR TITLE
feat: abstract social data sources fetchers and add unit tests

### DIFF
--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/Utils.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/Utils.scala
@@ -124,7 +124,9 @@ object Utils {
     searchInformation: List[SearchInfo],
     wallet           : SocialDataSourceAddress
   ): Boolean = searchInformation.exists { searchInfo =>
-    wallet.addressRewards.get(searchInfo.text.toLowerCase).fold(true)(_.dailyPostsNumber < searchInfo.maxPerDay)
+    wallet.addressRewards
+      .get(searchInfo.text.toLowerCase)
+      .fold(true)(_.dailyPostsNumber < searchInfo.maxPerDay)
   }
 
   def timeRangeFromDayStartTillNow(

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/Utils.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/Utils.scala
@@ -7,6 +7,8 @@ import cats.syntax.all._
 import eu.timepit.refined.types.all.PosLong
 import eu.timepit.refined.types.numeric.NonNegLong
 import org.elpaca_metagraph.shared_data.app.ApplicationConfig
+import org.elpaca_metagraph.shared_data.app.ApplicationConfig.SearchInfo
+import org.elpaca_metagraph.shared_data.types.Lattice.SocialDataSourceAddress
 import org.tessellation.currency.dataApplication.L0NodeContext
 import org.tessellation.env.env.{KeyAlias, Password, StorePath}
 import org.tessellation.ext.cats.syntax.next.catsSyntaxNext
@@ -127,4 +129,12 @@ object Utils {
     def toPosLongUnsafe: PosLong =
       PosLong.unsafeFrom(value)
   }
+
+  def isWithinDailyLimit(
+    searchInformation: List[SearchInfo],
+    wallet           : SocialDataSourceAddress
+  ): Boolean = searchInformation.exists { searchInfo =>
+    wallet.addressRewards.get(searchInfo.text.toLowerCase).fold(true)(_.dailyPostsNumber < searchInfo.maxPerDay)
+  }
+
 }

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/app/ApplicationConfig.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/app/ApplicationConfig.scala
@@ -79,11 +79,17 @@ object ApplicationConfig {
     walletsInfo: List[WalletsInfo]
   )
 
+  trait SearchInfo {
+    def text        : String
+    def rewardAmount: Amount
+    def maxPerDay   : Long
+  }
+
   case class XSearchInfo(
     text        : String,
     rewardAmount: Amount,
     maxPerDay   : Long
-  )
+  ) extends SearchInfo
 
   case class XDaemonConfig(
     idleTime          : FiniteDuration,
@@ -101,13 +107,13 @@ object ApplicationConfig {
   )
 
   case class YouTubeSearchInfo(
-    text                 : String,
-    rewardAmount         : Amount,
-    minimumDuration      : Long,
-    minimumViews         : Long,
-    maxPerDay            : Long,
-    publishedWithinHours : Long
-  )
+    text                : String,
+    rewardAmount        : Amount,
+    maxPerDay           : Long,
+    minimumDuration     : Long,
+    minimumViews        : Long,
+    publishedWithinHours: Long
+  ) extends SearchInfo
 
   case class YouTubeDaemonConfig(
     idleTime          : FiniteDuration,

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/app/ApplicationConfig.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/app/ApplicationConfig.scala
@@ -107,12 +107,13 @@ object ApplicationConfig {
   )
 
   case class YouTubeSearchInfo(
-    text                : String,
-    rewardAmount        : Amount,
-    maxPerDay           : Long,
-    minimumDuration     : Long,
-    minimumViews        : Long,
-    publishedWithinHours: Long
+    text                     : String,
+    rewardAmount             : Amount,
+    maxPerDay                : Long,
+    minimumViews             : Long,
+    minimumDuration          : FiniteDuration,
+    publishedWithinHours     : FiniteDuration,
+    daysToMonitorVideoUpdates: FiniteDuration
   ) extends SearchInfo
 
   case class YouTubeDaemonConfig(

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/combiners/XCombiner.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/combiners/XCombiner.scala
@@ -118,19 +118,19 @@ object XCombiner {
             if (data.epochProgressToReward === currentEpochProgress) {
               data
                 .focus(_.dailyPostsNumber)
-                .modify(current => current + 1)
+                .modify(_ + 1)
                 .focus(_.amountToReward)
                 .modify(current => current.plus(toTokenAmountFormat(searchInformation.rewardAmount)).getOrElse(current))
                 .focus(_.postIds)
-                .modify(current => current :+ xUpdate.postId)
+                .modify(_ :+ xUpdate.postId)
             } else {
               data
                 .focus(_.epochProgressToReward)
                 .replace(currentEpochProgress)
                 .focus(_.dailyPostsNumber)
-                .modify(current => current + 1)
+                .modify(_ + 1)
                 .focus(_.postIds)
-                .modify(current => current :+ xUpdate.postId)
+                .modify(_ :+ xUpdate.postId)
             }
           }
 

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/combiners/YouTubeCombiner.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/combiners/YouTubeCombiner.scala
@@ -2,7 +2,7 @@ package org.elpaca_metagraph.shared_data.combiners
 
 import cats.syntax.all._
 import monocle.Monocle.toAppliedFocusOps
-import org.elpaca_metagraph.shared_data.Utils.{isNewDay, toTokenAmountFormat}
+import org.elpaca_metagraph.shared_data.Utils._
 import org.elpaca_metagraph.shared_data.app.ApplicationConfig
 import org.elpaca_metagraph.shared_data.types.DataUpdates.YouTubeUpdate
 import org.elpaca_metagraph.shared_data.types.States.{DataSource, DataSourceType, YouTubeDataSource}
@@ -87,7 +87,13 @@ object YouTubeCombiner {
             }
           }
 
-          if (isNewDay(data.epochProgressToReward, currentEpochProgress)) {
+          if (data.dailyEpochProgress.value.value + epochProgressOneDay < data.epochProgressToReward.value.value) {
+            data
+              .focus(_.dailyEpochProgress)
+              .replace(data.epochProgressToReward)
+              .focus(_.dailyPostsNumber)
+              .replace(searchInformation.maxPerDay)
+          } else if (isNewDay(data.epochProgressToReward, currentEpochProgress)) {
             updateYoutubeRewardInfoNewDay()
           } else if (isNotExceedingDailyLimit && !videoAlreadyExists) {
             updateYTRewardInfoSameDay()

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/combiners/YouTubeCombiner.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/combiners/YouTubeCombiner.scala
@@ -65,9 +65,9 @@ object YouTubeCombiner {
 
           def isNotExceedingDailyLimit: Boolean = data.dailyPostsNumber < searchInformation.maxPerDay
 
-          def postAlreadyExists: Boolean = data.videos.contains(youTubeUpdate.video)
+          def videoAlreadyExists: Boolean = data.videos.contains(youTubeUpdate.video)
 
-          def updateXRewardInfoSameDay(): YouTubeRewardInfo = {
+          def updateYTRewardInfoSameDay(): YouTubeRewardInfo = {
             if (data.epochProgressToReward === currentEpochProgress) {
               data
                 .focus(_.dailyPostsNumber)
@@ -89,8 +89,8 @@ object YouTubeCombiner {
 
           if (isNewDay(data.epochProgressToReward, currentEpochProgress)) {
             updateYoutubeRewardInfoNewDay()
-          } else if (isNotExceedingDailyLimit && !postAlreadyExists) {
-            updateXRewardInfoSameDay()
+          } else if (isNotExceedingDailyLimit && !videoAlreadyExists) {
+            updateYTRewardInfoSameDay()
           } else {
             data
           }

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/combiners/YouTubeCombiner.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/combiners/YouTubeCombiner.scala
@@ -1,10 +1,13 @@
 package org.elpaca_metagraph.shared_data.combiners
 
 import cats.syntax.all._
+import eu.timepit.refined.types.numeric.NonNegLong
 import monocle.Monocle.toAppliedFocusOps
 import org.elpaca_metagraph.shared_data.Utils._
 import org.elpaca_metagraph.shared_data.app.ApplicationConfig
+import org.elpaca_metagraph.shared_data.app.ApplicationConfig.SearchInfo
 import org.elpaca_metagraph.shared_data.types.DataUpdates.YouTubeUpdate
+import org.elpaca_metagraph.shared_data.types.Lattice.RewardInfo
 import org.elpaca_metagraph.shared_data.types.States.{DataSource, DataSourceType, YouTubeDataSource}
 import org.elpaca_metagraph.shared_data.types.YouTube.{YouTubeDataSourceAddress, YouTubeRewardInfo}
 import org.tessellation.schema.epoch.EpochProgress
@@ -41,88 +44,134 @@ object YouTubeCombiner {
     youTubeUpdate: YouTubeUpdate,
     applicationConfig: ApplicationConfig
   ): YouTubeDataSource = {
-    val maybeSearchInformation = applicationConfig.youtubeDaemon.searchInformation.find(_.text == youTubeUpdate.searchText)
+    val searchInformation = applicationConfig.youtubeDaemon.searchInformation
     val youtubeDatasource = getYouTubeDatasource(currentCalculatedState)
     val youTubeDataSourceAddress = youtubeDatasource.existingWallets.getOrElse(youTubeUpdate.address, YouTubeDataSourceAddress())
 
-    maybeSearchInformation.fold(youtubeDatasource) { searchInformation =>
-      val updatedData = youTubeDataSourceAddress.addressRewards
-        .get(youTubeUpdate.searchText)
-        .map { data =>
-          def updateYoutubeRewardInfoNewDay() = {
-            data
-              .focus(_.dailyEpochProgress)
-              .replace(currentEpochProgress)
-              .focus(_.epochProgressToReward)
-              .replace(currentEpochProgress)
-              .focus(_.dailyPostsNumber)
-              .replace(1)
-              .focus(_.amountToReward)
-              .replace(toTokenAmountFormat(searchInformation.rewardAmount))
-              .focus(_.videos)
-              .replace(List(youTubeUpdate.video))
-          }
+    searchInformation
+      .find(_.text.toLowerCase == youTubeUpdate.searchText.toLowerCase)
+      .fold(youtubeDatasource) { searchTerm =>
+        val updatedRewardInfo = youTubeDataSourceAddress.addressRewards.get(youTubeUpdate.searchText.toLowerCase).map { data =>
+          val currentRewardInfo = if (data.rewardCandidates.isEmpty) {
+            data.focus(_.rewardCandidates).replace(Some(List.empty))
+          } else data
 
-          def isNotExceedingDailyLimit: Boolean = data.dailyPostsNumber < searchInformation.maxPerDay
+          val rewardInfo = if (isRewardInfoExpired(currentRewardInfo)) {
+            currentRewardInfo
+              .focus(_.dailyEpochProgress).replace(currentRewardInfo.epochProgressToReward)
+              .focus(_.dailyPostsNumber).replace(searchTerm.maxPerDay)
+          } else if (isNewDay(currentRewardInfo.epochProgressToReward, currentEpochProgress)) {
+            val firstRewardOfTheDay = currentRewardInfo
+              .focus(_.dailyEpochProgress).replace(currentEpochProgress)
+              .focus(_.amountToReward).replace(toTokenAmountFormat(0))
+              .focus(_.dailyPostsNumber).replace(0)
+              .focus(_.videos).replace(List.empty)
+              .focus(_.rewardCandidates).modify(_.map(_.filterNot(_.checkUntil.exists(_.value.value <= currentEpochProgress.value.value))))
 
-          def videoAlreadyExists: Boolean = data.videos.contains(youTubeUpdate.video)
-
-          def updateYTRewardInfoSameDay(): YouTubeRewardInfo = {
-            if (data.epochProgressToReward === currentEpochProgress) {
-              data
-                .focus(_.dailyPostsNumber)
-                .modify(current => current + 1)
-                .focus(_.amountToReward)
-                .modify(current => current.plus(toTokenAmountFormat(searchInformation.rewardAmount)).getOrElse(current))
-                .focus(_.videos)
-                .modify(current => current :+ youTubeUpdate.video)
-            } else {
-              data
-                .focus(_.epochProgressToReward)
-                .replace(currentEpochProgress)
-                .focus(_.dailyPostsNumber)
-                .modify(current => current + 1)
-                .focus(_.videos)
-                .modify(current => current :+ youTubeUpdate.video)
-            }
-          }
-
-          if (data.dailyEpochProgress.value.value + epochProgressOneDay < data.epochProgressToReward.value.value) {
-            data
-              .focus(_.dailyEpochProgress)
-              .replace(data.epochProgressToReward)
-              .focus(_.dailyPostsNumber)
-              .replace(searchInformation.maxPerDay)
-          } else if (isNewDay(data.epochProgressToReward, currentEpochProgress)) {
-            updateYoutubeRewardInfoNewDay()
-          } else if (isNotExceedingDailyLimit && !videoAlreadyExists) {
-            updateYTRewardInfoSameDay()
+            buildRewardInfo(currentEpochProgress, youTubeUpdate, searchTerm, firstRewardOfTheDay)
+          } else if (isStillAllowedToReward(youTubeUpdate, searchInformation, youtubeDatasource, searchTerm, currentRewardInfo)) {
+            buildRewardInfo(currentEpochProgress, youTubeUpdate, searchTerm, currentRewardInfo)
+          } else if (youTubeUpdate.video.views >= searchTerm.minimumViews) {
+              val updatedVideo = youTubeUpdate.copy(video = youTubeUpdate.video.copy(checkUntil = None))
+              currentRewardInfo.focus(_.rewardCandidates).modify(_.map(_.filterNot(_.id == updatedVideo.video.id) :+ updatedVideo.video))
           } else {
-            data
+            currentRewardInfo
           }
-        }.getOrElse(YouTubeRewardInfo(
-          currentEpochProgress,
-          currentEpochProgress,
-          toTokenAmountFormat(searchInformation.rewardAmount),
-          searchInformation.text,
-          List(youTubeUpdate.video),
-          1
-        ))
 
-      val updatedDataSourceAddress = youTubeDataSourceAddress
-        .focus(_.addressRewards)
-        .modify(_.updated(youTubeUpdate.searchText, updatedData))
+          rewardInfo.focus(_.epochProgressToReward).replace(currentEpochProgress)
+        }.getOrElse(buildFirstRewardInfo(currentEpochProgress, youTubeUpdate, searchTerm))
 
-      youtubeDatasource
-        .focus(_.existingWallets)
-        .modify(_.updated(youTubeUpdate.address, updatedDataSourceAddress))
+        val updatedDataSourceAddress = youTubeDataSourceAddress
+          .focus(_.addressRewards)
+          .modify(_.updated(youTubeUpdate.searchText.toLowerCase, updatedRewardInfo))
+
+        youtubeDatasource
+          .focus(_.existingWallets)
+          .modify(_.updated(youTubeUpdate.address, updatedDataSourceAddress))
+      }
+  }
+
+  private def isStillAllowedToReward(
+    youTubeUpdate: YouTubeUpdate,
+    searchInformation: List[ApplicationConfig.YouTubeSearchInfo],
+    youtubeDatasource: YouTubeDataSource,
+    searchTerm: ApplicationConfig.YouTubeSearchInfo,
+    currentRewardInfo: YouTubeRewardInfo
+  ): Boolean = {
+    isNotYetRewarded(searchInformation, youTubeUpdate, youtubeDatasource) && currentRewardInfo.dailyPostsNumber < searchTerm.maxPerDay
+  }
+
+  private def isRewardInfoExpired(
+    currentRewardInfo: YouTubeRewardInfo
+  ): Boolean =
+    currentRewardInfo.dailyEpochProgress.value.value + epochProgressOneDay < currentRewardInfo.epochProgressToReward.value.value
+
+  private def isNotYetRewarded(
+    searchInformation: List[SearchInfo],
+    youTubeUpdate: YouTubeUpdate,
+    youtubeDatasource: YouTubeDataSource
+  ): Boolean = {
+    youtubeDatasource.existingWallets.get(youTubeUpdate.address).fold(true) { wallet =>
+      !searchInformation.exists { searchTerm =>
+        wallet.addressRewards.get(searchTerm.text.toLowerCase).exists(_.videos.map(_.id).contains(youTubeUpdate.video.id))
+      }
     }
   }
 
-  private def getYouTubeDatasource(currentCalculatedState: Map[DataSourceType, DataSource]): YouTubeDataSource = {
+  private def buildRewardInfo(
+    currentEpochProgress: EpochProgress,
+    youTubeUpdate: YouTubeUpdate,
+    searchTerm: ApplicationConfig.YouTubeSearchInfo,
+    currentRewardInfo: YouTubeRewardInfo
+  ): YouTubeRewardInfo = {
+    if (youTubeUpdate.video.views >= searchTerm.minimumViews) {
+      val rewardInfoWithUpdatedAmount = if (currentEpochProgress === currentRewardInfo.epochProgressToReward) {
+        currentRewardInfo
+          .focus(_.amountToReward).modify(current => current.plus(toTokenAmountFormat(searchTerm.rewardAmount)).getOrElse(current))
+      } else currentRewardInfo
+
+      rewardInfoWithUpdatedAmount
+        .focus(_.dailyPostsNumber).modify(_ + 1)
+        .focus(_.videos).modify(_ :+ youTubeUpdate.video)
+        .focus(_.rewardCandidates).modify(_.map(_.filterNot(_.id == youTubeUpdate.video.id)))
+    } else if (!currentRewardInfo.rewardCandidates.exists(_.map(_.id).contains(youTubeUpdate.video.id))) {
+      val updatedVideo = youTubeUpdate.video.copy(checkUntil = Some(getExpirationEpoch(searchTerm, currentRewardInfo)))
+
+      currentRewardInfo
+        .focus(_.rewardCandidates).modify(_.map(_.filterNot(_.id == youTubeUpdate.video.id) :+ updatedVideo))
+    } else currentRewardInfo
+  }
+
+  private def getExpirationEpoch(
+    searchInformation: ApplicationConfig.YouTubeSearchInfo,
+    currentRewardInfo: RewardInfo
+  ): EpochProgress =
+    EpochProgress(
+      NonNegLong
+        .from(currentRewardInfo.dailyEpochProgress.value.value + searchInformation.daysToMonitorVideoUpdates.toDays * epochProgressOneDay.toLong)
+        .getOrElse(NonNegLong(0L))
+    )
+
+  private def buildFirstRewardInfo(
+    currentEpochProgress: EpochProgress,
+    youTubeUpdate: YouTubeUpdate,
+    searchInformation: ApplicationConfig.YouTubeSearchInfo
+  ): YouTubeRewardInfo =
+    YouTubeRewardInfo(
+      dailyEpochProgress = currentEpochProgress,
+      epochProgressToReward = currentEpochProgress,
+      amountToReward = toTokenAmountFormat(searchInformation.rewardAmount),
+      searchText = searchInformation.text.toLowerCase,
+      dailyPostsNumber = 1,
+      videos = List(youTubeUpdate.video),
+      rewardCandidates = Some(List.empty)
+    )
+
+  private def getYouTubeDatasource(
+    currentCalculatedState: Map[DataSourceType, DataSource]
+  ): YouTubeDataSource =
     currentCalculatedState
       .get(DataSourceType.YouTube)
       .collect { case ds: YouTubeDataSource => ds }
       .getOrElse(YouTubeDataSource(Map.empty))
-  }
 }

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/LatticeFetcher.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/LatticeFetcher.scala
@@ -34,12 +34,12 @@ class LatticeFetcher[F[_]: Async: Network](
         logger.error(e)(s"Error fetching Lattice users: ${e.getMessage}").as(LatticeUsersApiResponse(List.empty, None))
       }
       newUsers = users ++ response.data
-      result <-
+      latticeUsers <-
         if (!response.meta.exists(meta => meta.offset + meta.limit < meta.total)) {
-          newUsers.filter(_.primaryDagAddress.isDefined).pure
+          val result = newUsers.filter(_.primaryDagAddress.isDefined)
+          logger.info(s"Found ${result.length} Lattice users").as(result)
         } else fetchLatticeUsers(response.meta.get.offset + response.meta.get.limit, newUsers)
-      _ <- logger.info(s"Found ${result.length} Lattice users")
-    } yield result
+    } yield latticeUsers
   }
 
   def fetchLatticeUsersWithYouTubeAccount(

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/LatticeFetcher.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/LatticeFetcher.scala
@@ -1,0 +1,58 @@
+package org.elpaca_metagraph.shared_data.daemons.fetcher
+
+import cats.effect.Async
+import cats.syntax.all._
+import fs2.io.net.Network
+import org.elpaca_metagraph.shared_data.types.Lattice._
+import org.elpaca_metagraph.shared_data.types.Refined.ApiUrl
+import org.http4s.circe.jsonOf
+import org.http4s.client.Client
+import org.http4s.{Method, Request, Uri}
+import org.typelevel.log4cats.SelfAwareStructuredLogger
+
+class LatticeFetcher[F[_]: Async: Network](
+  apiUrl: ApiUrl
+)(implicit client: Client[F],
+  logger: SelfAwareStructuredLogger[F]) {
+
+  def fetchLatticeUsers(
+    offset: Long = 0,
+    users : List[LatticeUser] = List.empty
+  ): F[List[LatticeUser]] = {
+    val usersPerRequest = 100
+    val request = Request[F](
+      Method.GET,
+      Uri
+        .unsafeFromString(apiUrl.toString())
+        .withQueryParam("limit", usersPerRequest)
+        .withQueryParam("offset", offset)
+    )
+
+    for {
+      _ <- logger.info(s"Fetching Lattice users from $apiUrl with offset $offset")
+      response <- client.expect[LatticeUsersApiResponse](request)(jsonOf[F, LatticeUsersApiResponse]).handleErrorWith { e =>
+        logger.error(e)(s"Error fetching Lattice users: ${e.getMessage}").as(LatticeUsersApiResponse(List.empty, None))
+      }
+      newUsers = users ++ response.data
+      result <-
+        if (!response.meta.exists(meta => meta.offset + meta.limit < meta.total)) {
+          newUsers.filter(_.primaryDagAddress.isDefined).pure
+        } else fetchLatticeUsers(response.meta.get.offset + response.meta.get.limit, newUsers)
+      _ <- logger.info(s"Found ${result.length} Lattice users")
+    } yield result
+  }
+
+  def fetchLatticeUsersWithYouTubeAccount(
+    offset: Long = 0
+  ): F[List[LatticeUser]] = for {
+    users <- fetchLatticeUsers(offset).map(_.filter(_.youtube.isDefined))
+    _ <- logger.info(s"Found ${users.length} Lattice users with YouTube account")
+  } yield users
+
+  def fetchLatticeUsersWithXAccount(
+    offset: Long = 0
+  ): F[List[LatticeUser]] = for {
+    users <- fetchLatticeUsers(offset).map(_.filter(_.twitter.isDefined))
+    _ <- logger.info(s"Found ${users.length} Lattice users with X account")
+  } yield users
+}

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/LatticeFetcher.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/LatticeFetcher.scala
@@ -45,14 +45,14 @@ class LatticeFetcher[F[_]: Async: Network](
   def fetchLatticeUsersWithYouTubeAccount(
     offset: Long = 0
   ): F[List[LatticeUser]] = for {
-    users <- fetchLatticeUsers(offset).map(_.filter(_.youtube.isDefined))
+    users <- fetchLatticeUsers(offset).map(_.filter(_.linkedAccounts.youtube.isDefined))
     _ <- logger.info(s"Found ${users.length} Lattice users with YouTube account")
   } yield users
 
   def fetchLatticeUsersWithXAccount(
     offset: Long = 0
   ): F[List[LatticeUser]] = for {
-    users <- fetchLatticeUsers(offset).map(_.filter(_.twitter.isDefined))
+    users <- fetchLatticeUsers(offset).map(_.filter(_.linkedAccounts.twitter.isDefined))
     _ <- logger.info(s"Found ${users.length} Lattice users with X account")
   } yield users
 }

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/LatticeFetcher.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/LatticeFetcher.scala
@@ -45,14 +45,14 @@ class LatticeFetcher[F[_]: Async: Network](
   def fetchLatticeUsersWithYouTubeAccount(
     offset: Long = 0
   ): F[List[LatticeUser]] = for {
-    users <- fetchLatticeUsers(offset).map(_.filter(_.linkedAccounts.youtube.isDefined))
+    users <- fetchLatticeUsers(offset).map(_.filter(_.linkedAccounts.exists(_.youtube.isDefined)))
     _ <- logger.info(s"Found ${users.length} Lattice users with YouTube account")
   } yield users
 
   def fetchLatticeUsersWithXAccount(
     offset: Long = 0
   ): F[List[LatticeUser]] = for {
-    users <- fetchLatticeUsers(offset).map(_.filter(_.linkedAccounts.twitter.isDefined))
+    users <- fetchLatticeUsers(offset).map(_.filter(user => user.twitter.isDefined || user.linkedAccounts.exists(_.twitter.isDefined)))
     _ <- logger.info(s"Found ${users.length} Lattice users with X account")
   } yield users
 }

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/XFetcher.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/XFetcher.scala
@@ -88,7 +88,7 @@ object XFetcher {
 
   def validateIfAddressCanProceed(
     xDataSource      : XDataSource,
-    searchInformation: List[ApplicationConfig.XSearchInfo],
+    searchInformation: List[ApplicationConfig.SearchInfo],
     address          : Address,
     maybePostId      : Option[String]
   ): Boolean = xDataSource.existingWallets.get(address).fold(true) { existingWallet =>
@@ -120,9 +120,9 @@ object XFetcher {
   }
 
   def removeAlreadyRewardedSearches(
-  xPosts           : List[XDataInfo],
-  searchInformation: List[ApplicationConfig.XSearchInfo],
-  xDataSource      : XDataSource
+    xPosts           : List[XDataInfo],
+    searchInformation: List[ApplicationConfig.XSearchInfo],
+    xDataSource      : XDataSource
   ): List[XDataInfo] = xPosts.filter { xPost =>
     xDataSource.existingWallets.get(xPost.dagAddress).fold(true) { existingWallet =>
       existingWallet.addressRewards.get(xPost.searchText.toLowerCase).fold(true) { xRewardInfo =>

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/XFetcher.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/XFetcher.scala
@@ -177,7 +177,7 @@ object XFetcher {
         sourceUsers <- latticeFetcher.fetchLatticeUsersWithXAccount()
         eligibleSourceUsers = sourceUsers.filter { user =>
           user.primaryDagAddress.flatMap { address =>
-            user.twitter.map { _ =>
+            user.linkedAccounts.twitter.map { _ =>
               validateIfAddressCanProceed(xDataSource, searchInformation, address, none)
             }
           }.getOrElse(false)
@@ -194,7 +194,7 @@ object XFetcher {
 
         searchInfo = searchInformation.map(_.text).mkString("\" OR \"")
         xPosts <- filteredUsers.traverse { userInfo =>
-          val username = userInfo.twitter.get.username
+          val username = userInfo.linkedAccounts.twitter.get.username
           val primaryDAGAddress = userInfo.primaryDagAddress.get
           val xSearchResult = xFetcher.fetchXPosts(
             username,

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/XFetcher.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/XFetcher.scala
@@ -1,17 +1,17 @@
 package org.elpaca_metagraph.shared_data.daemons.fetcher
 
-
-import cats.effect.{Async, Resource}
+import cats.effect.Async
 import cats.syntax.all._
 import com.github.scribejava.apis.TwitterApi
 import com.github.scribejava.core.builder.ServiceBuilder
 import com.github.scribejava.core.model.{OAuth1AccessToken, OAuthRequest, Verb}
 import com.github.scribejava.core.oauth.OAuth10aService
 import fs2.io.net.Network
-import io.circe.generic.auto._
+import org.elpaca_metagraph.shared_data.Utils.isWithinDailyLimit
 import org.elpaca_metagraph.shared_data.app.ApplicationConfig
 import org.elpaca_metagraph.shared_data.calculated_state.CalculatedStateService
-import org.elpaca_metagraph.shared_data.types.DataUpdates.{ElpacaUpdate, XUpdate}
+import org.elpaca_metagraph.shared_data.types.Lattice.LatticeUser
+import org.elpaca_metagraph.shared_data.types.DataUpdates.XUpdate
 import org.elpaca_metagraph.shared_data.types.Refined.ApiUrl
 import org.elpaca_metagraph.shared_data.types.States.{DataSourceType, XDataSource}
 import org.elpaca_metagraph.shared_data.types.X._
@@ -28,244 +28,219 @@ import java.time.format.DateTimeFormatter
 import java.time.{Instant, LocalDateTime, ZoneOffset}
 import scala.jdk.CollectionConverters._
 
-object XFetcher {
+class XFetcher[F[_]: Async: Network](
+  apiUrl            : ApiUrl,
+  xApiConsumerKey   : String,
+  xApiConsumerSecret: String,
+  xApiAccessToken   : String,
+  xApiAccessSecret  : String
+)(implicit client: Client[F],
+  logger: SelfAwareStructuredLogger[F]) {
 
+  def fetchXPosts(
+    username       : String,
+    searchText     : String,
+    currentDateTime: LocalDateTime
+  ): F[List[XPost]] = {
+    val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+    val dateTimeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
+    val currentDateFormatted: String = currentDateTime.format(dateFormatter)
+    val currentDateTimeFormatted: String = currentDateTime.minusMinutes(1).format(dateTimeFormatter)
+
+    val service: OAuth10aService = new ServiceBuilder(xApiConsumerKey)
+      .apiSecret(xApiConsumerSecret)
+      .build(TwitterApi.instance())
+
+    val query = s"from:$username (\"$searchText\") -is:reply -is:retweet"
+    val requestURI = Uri
+      .unsafeFromString(apiUrl.toString())
+      .withQueryParam("query", query)
+      .withQueryParam("start_time", s"${currentDateFormatted}T00:00:00Z")
+      .withQueryParam("end_time", s"$currentDateTimeFormatted")
+      .withQueryParam("tweet.fields", "note_tweet")
+
+    logger.info(s"Fetching X Url: ${requestURI.toString()}").flatMap { _ =>
+      val oauthRequest = new OAuthRequest(Verb.GET, requestURI.toString())
+      val token = new OAuth1AccessToken(xApiAccessToken, xApiAccessSecret)
+      service.signRequest(token, oauthRequest)
+
+      val headers = oauthRequest.getHeaders.entrySet().asScala.foldLeft(List.empty[Header.Raw]) { (acc, entry) =>
+          acc :+ Header.Raw(CIString(entry.getKey), entry.getValue)
+      }
+
+      val signedRequest = Request[F](
+        method = Method.GET,
+        uri = Uri.unsafeFromString(oauthRequest.getCompleteUrl)
+      ).withHeaders(headers)
+
+      client.expect[XApiResponse](signedRequest)(jsonOf[F, XApiResponse]).map(_.data.getOrElse(List.empty[XPost]))
+    }
+  }
+}
+
+object XFetcher {
   private val groupsNumber: Int = 4
   private val xRateLimitMinutes: Int = 15
 
-  def make[F[_] : Async : Network](
+  def splitUsersIntoGroups(
+    users: List[LatticeUser]
+  ): List[List[LatticeUser]] = {
+    val groupSize = (users.size / groupsNumber.toDouble).ceil.toInt
+    users.grouped(groupSize).toList.take(groupsNumber)
+  }
+
+  def getCurrentGroupIndex: Int = (Instant.now().atZone(ZoneOffset.UTC).getMinute / xRateLimitMinutes) % groupsNumber
+
+  def validateIfAddressCanProceed(
+    xDataSource      : XDataSource,
+    searchInformation: List[ApplicationConfig.XSearchInfo],
+    address          : Address,
+    maybePostId      : Option[String]
+  ): Boolean = xDataSource.existingWallets.get(address).fold(true) { existingWallet =>
+    val postIdNotUsed = maybePostId.forall { postId =>
+      !searchInformation.exists { searchInfo =>
+        existingWallet.addressRewards.get(searchInfo.text.toLowerCase).exists(_.postIds.contains(postId))
+      }
+    }
+
+    postIdNotUsed && isWithinDailyLimit(searchInformation, existingWallet)
+  }
+
+  def filterAlreadyRewardedSearches(
+    xPosts           : List[XDataInfo],
+    searchInformation: List[ApplicationConfig.XSearchInfo],
+    xDataSource      : XDataSource
+  ): List[XDataInfo] = xPosts.filter { xPost =>
+    xDataSource.existingWallets.get(xPost.dagAddress).fold(true) { existingWallet =>
+      existingWallet.addressRewards.get(xPost.searchText.toLowerCase).fold(true) { xRewardInfo =>
+        val searchTextMaxPerDay = searchInformation
+          .find(_.text.toLowerCase === xRewardInfo.searchText.toLowerCase)
+          .map(_.maxPerDay)
+          .getOrElse(0L)
+
+        xRewardInfo.dailyPostsNumber < searchTextMaxPerDay
+      }
+    }
+  }
+
+  def make[F[_]: Async: Network](
     applicationConfig     : ApplicationConfig,
     calculatedStateService: CalculatedStateService[F]
-  ): Fetcher[F] =
-    new Fetcher[F] {
-      private val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromClass(XFetcher.getClass)
+  ): Fetcher[F] = (currentDateTime: LocalDateTime) =>
+    MkHttpClient.forAsync[F].newEmber(applicationConfig.http4s.client).use { implicit client =>
+      implicit val logger: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromClass(XFetcher.getClass)
 
-      def fetchAllSourceUsers(
-        baseUrl         : ApiUrl,
-        initialOffset   : Long = 0,
-        accumulatedUsers: List[SourceUser] = List.empty
-      ): F[List[SourceUser]] = {
-        val clientResource: Resource[F, Client[F]] = MkHttpClient.forAsync[F].newEmber(applicationConfig.http4s.client)
-        val usersPerRequest: Long = 100
-        clientResource.use { client =>
-          val requestURI = Uri.unsafeFromString(baseUrl.toString())
-            .withQueryParam("limit", usersPerRequest)
-            .withQueryParam("offset", initialOffset)
+      val xConfig = applicationConfig.xDaemon
 
-          val request = Request[F](
-            method = Method.GET,
-            uri = requestURI
-          )
+      for {
+        usersSourceApiUrl <- xConfig.usersSourceApiUrl.toOptionT.getOrRaise(new Exception(s"Could not get usersSourceApiUrl"))
+        xApiUrl <- xConfig.xApiUrl.toOptionT.getOrRaise(new Exception(s"Could not get xApiUrl"))
+        xApiConsumerKey <- xConfig.xApiConsumerKey.toOptionT.getOrRaise(new Exception(s"Could not get xApiConsumerKey"))
+        xApiConsumerSecret <- xConfig.xApiConsumerSecret.toOptionT.getOrRaise(new Exception(s"Could not get xApiConsumerSecret"))
+        xApiAccessToken <- xConfig.xApiAccessToken.toOptionT.getOrRaise(new Exception(s"Could not get xApiAccessToken"))
+        xApiAccessSecret <- xConfig.xApiAccessSecret.toOptionT.getOrRaise(new Exception(s"Could not get xApiAccessSecret"))
 
-          client.expect[SourceUsersApiResponse](request)(jsonOf[F, SourceUsersApiResponse]).flatMap { response =>
-            val newUsers = accumulatedUsers ++ response.data
-            if (response.meta.exists(meta => meta.offset + meta.limit < meta.total)) {
-              fetchAllSourceUsers(baseUrl, response.meta.get.offset + response.meta.get.limit, newUsers)
-            } else {
-              newUsers.pure
+        calculatedState <- calculatedStateService.get
+        xDataSource: XDataSource = calculatedState.state.dataSources
+          .get(DataSourceType.X)
+          .collect { case ds: XDataSource => ds }
+          .getOrElse(XDataSource(Map.empty))
+
+        searchInformation = xConfig.searchInformation
+
+        latticeFetcher = new LatticeFetcher[F](usersSourceApiUrl)
+        xFetcher = new XFetcher[F](
+          xApiUrl,
+          xApiConsumerKey,
+          xApiConsumerSecret,
+          xApiAccessToken,
+          xApiAccessSecret
+        )
+        sourceUsers <- latticeFetcher.fetchLatticeUsersWithXAccount()
+        eligibleSourceUsers = sourceUsers.filter { user =>
+          user.primaryDagAddress.flatMap { address =>
+            user.twitter.map { _ =>
+              validateIfAddressCanProceed(xDataSource, searchInformation, address, none)
             }
-          }
-        }
-      }
-
-      def fetchXPosts(
-        username          : String,
-        searchText        : String,
-        url               : ApiUrl,
-        xApiConsumerKey   : String,
-        xApiConsumerSecret: String,
-        xApiAccessToken   : String,
-        xApiAccessSecret  : String,
-        currentDateTime   : LocalDateTime
-      ):
-      F[List[XPost]] = {
-        val clientResource: Resource[F, Client[F]] = MkHttpClient.forAsync[F].newEmber(applicationConfig.http4s.client)
-
-        val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
-        val dateTimeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
-        val currentDateFormatted: String = currentDateTime.format(dateFormatter)
-        val currentDateTimeFormatted: String = currentDateTime.minusMinutes(1).format(dateTimeFormatter)
-
-        val service: OAuth10aService = new ServiceBuilder(xApiConsumerKey)
-          .apiSecret(xApiConsumerSecret)
-          .build(TwitterApi.instance())
-
-        clientResource.use { client =>
-          val query = s"from:$username (\"$searchText\") -is:reply -is:retweet"
-          val requestURI = Uri.unsafeFromString(url.toString()).withQueryParam("query", query)
-            .withQueryParam("start_time", s"${currentDateFormatted}T00:00:00Z")
-            .withQueryParam("end_time", s"$currentDateTimeFormatted")
-            .withQueryParam("tweet.fields", "note_tweet")
-
-          logger.info(s"Fetching X Url: ${requestURI.toString()}").flatMap { _ =>
-            val oauthRequest = new OAuthRequest(Verb.GET, requestURI.toString())
-            val token = new OAuth1AccessToken(xApiAccessToken, xApiAccessSecret)
-            service.signRequest(token, oauthRequest)
-
-            val headers = oauthRequest.getHeaders.entrySet().asScala.foldLeft(List.empty[Header.Raw]) { (acc, entry) =>
-              acc :+ Header.Raw(CIString(entry.getKey), entry.getValue)
-            }
-
-            val signedRequest = Request[F](
-              method = Method.GET,
-              uri = Uri.unsafeFromString(oauthRequest.getCompleteUrl)
-            ).withHeaders(headers)
-
-            client.expect[XApiResponse](signedRequest)(jsonOf[F, XApiResponse]).map(_.data.getOrElse(List.empty[XPost]))
-          }
-        }
-      }
-
-
-      def splitUsersIntoGroups(users: List[SourceUser]): List[List[SourceUser]] = {
-        val groupSize = (users.size / groupsNumber.toDouble).ceil.toInt
-        users.grouped(groupSize).toList.take(groupsNumber)
-      }
-
-      def getCurrentGroupIndex: Int =
-        (Instant.now().atZone(ZoneOffset.UTC).getMinute / xRateLimitMinutes) % groupsNumber
-
-      def validateIfAddressCanProceed(
-        xDataSource      : XDataSource,
-        searchInformation: List[ApplicationConfig.XSearchInfo],
-        address          : Address,
-        maybePostId      : Option[String]
-      ): Boolean =
-        xDataSource.existingWallets.get(address).fold(true) { existingWallet =>
-          val postIdNotUsed = maybePostId.forall { postId =>
-            !searchInformation.exists { searchInfo =>
-              existingWallet.addressRewards.get(searchInfo.text.toLowerCase).exists(_.postIds.contains(postId))
-            }
-          }
-
-          val canProceedWithPosts = searchInformation.exists { searchInfo =>
-            existingWallet.addressRewards.get(searchInfo.text.toLowerCase).fold(true)(_.dailyPostsNumber < searchInfo.maxPerDay)
-          }
-
-          postIdNotUsed && canProceedWithPosts
+          }.getOrElse(false)
         }
 
-      def filterAlreadyRewardedSearches(
-        xPosts           : List[XDataInfo],
-        searchInformation: List[ApplicationConfig.XSearchInfo],
-        xDataSource      : XDataSource
-      ): List[XDataInfo] = xPosts.filter { xPost =>
-        xDataSource.existingWallets.get(xPost.dagAddress).fold(true) { existingWallet =>
-          existingWallet.addressRewards.get(xPost.searchText.toLowerCase).fold(true) { xRewardInfo =>
-            val searchTextMaxPerDay = searchInformation
-              .find(_.text.toLowerCase === xRewardInfo.searchText.toLowerCase)
-              .map(_.maxPerDay)
-              .getOrElse(0L)
+        groups = splitUsersIntoGroups(eligibleSourceUsers)
+        currentGroupIndex = getCurrentGroupIndex
 
-            xRewardInfo.dailyPostsNumber < searchTextMaxPerDay
-          }
-        }
-      }
+        filteredUsers = groups(currentGroupIndex)
+        _ <- logger.info(
+          s"Found ${sourceUsers.length} sourceUsers" +
+            s"\nFound ${filteredUsers.length} sourceUsersFiltered. Current group index: $currentGroupIndex"
+        )
 
-      override def getAddressesAndBuildUpdates(currentDateTime: LocalDateTime): F[List[ElpacaUpdate]] = {
-        val xConfig = applicationConfig.xDaemon
+        currentPostsIds = xDataSource.existingWallets.values
+          .flatMap(_.addressRewards.values)
+          .flatMap(_.postIds)
+          .toList
 
-        for {
-          usersSourceApiUrl <- xConfig.usersSourceApiUrl.toOptionT.getOrRaise(new Exception(s"Could not get usersSourceApiUrl"))
-          xApiUrl <- xConfig.xApiUrl.toOptionT.getOrRaise(new Exception(s"Could not get xApiUrl"))
-          xApiConsumerKey <- xConfig.xApiConsumerKey.toOptionT.getOrRaise(new Exception(s"Could not get xApiConsumerKey"))
-          xApiConsumerSecret <- xConfig.xApiConsumerSecret.toOptionT.getOrRaise(new Exception(s"Could not get xApiConsumerSecret"))
-          xApiAccessToken <- xConfig.xApiAccessToken.toOptionT.getOrRaise(new Exception(s"Could not get xApiAccessToken"))
-          xApiAccessSecret <- xConfig.xApiAccessSecret.toOptionT.getOrRaise(new Exception(s"Could not get xApiAccessSecret"))
-
-          calculatedState <- calculatedStateService.get
-          xDataSource: XDataSource = calculatedState.state.dataSources
-            .get(DataSourceType.X)
-            .collect { case ds: XDataSource => ds }
-            .getOrElse(XDataSource(Map.empty))
-
-          searchInformation = xConfig.searchInformation
-
-          sourceUsers <- fetchAllSourceUsers(usersSourceApiUrl)
-          eligibleSourceUsers = sourceUsers.filter { user =>
-            user.primaryDagAddress.flatMap { address =>
-              user.twitter.map { _ =>
-                validateIfAddressCanProceed(xDataSource, searchInformation, address, none)
-              }
-            }.getOrElse(false)
-          }
-
-          groups = splitUsersIntoGroups(eligibleSourceUsers)
-          currentGroupIndex = getCurrentGroupIndex
-
-          filteredUsers = groups(currentGroupIndex)
-          _ <- logger.info(s"Found ${sourceUsers.length} sourceUsers")
-          _ <- logger.info(s"Found ${filteredUsers.length} sourceUsersFiltered. Current group index: ${currentGroupIndex}")
-
-          currentPostsIds = xDataSource
-            .existingWallets
-            .values
-            .flatMap(_.addressRewards.values)
-            .flatMap(_.postIds)
-            .toList
-
-          searchInfo = searchInformation.map(_.text).mkString("\" OR \"")
-          xPosts <- filteredUsers.traverse { userInfo =>
-            val username = userInfo.twitter.get.username
-            val primaryDAGAddress = userInfo.primaryDagAddress.get
-            fetchXPosts(
-              username,
-              searchInfo,
-              xApiUrl,
-              xApiConsumerKey,
-              xApiConsumerSecret,
-              xApiAccessToken,
-              xApiAccessSecret,
-              currentDateTime
-            ).handleErrorWith { err =>
-              logger.error(err)(s"Error when fetching XPosts for user: $username").as(List.empty[XPost])
-            }.flatMap { xPosts =>
-              xPosts
-                .filter { xPost =>
-                  searchInformation.exists(searchInfo => xPost.text.toLowerCase.contains(searchInfo.text.toLowerCase))
-                }
-                .traverse { xPost =>
-                  searchInformation
-                    .find(searchInfo => xPost.text.toLowerCase.contains(searchInfo.text.toLowerCase))
-                    .fold {
-                      val defaultSearchInfo = searchInformation.head
-                      logger.warn(s"Could not get searchInformation from post: $xPost, setting $defaultSearchInfo").as(
-                        XDataInfo(
-                          xPost.id,
-                          primaryDAGAddress,
-                          defaultSearchInfo.text,
-                          defaultSearchInfo.maxPerDay
-                        )
-                      )
-                    } { searchInfo =>
-                      XDataInfo(
+        searchInfo = searchInformation.map(_.text).mkString("\" OR \"")
+        xPosts <- filteredUsers.traverse { userInfo =>
+          val username = userInfo.twitter.get.username
+          val primaryDAGAddress = userInfo.primaryDagAddress.get
+          xFetcher.fetchXPosts(
+            username,
+            searchInfo,
+            currentDateTime
+          ).handleErrorWith { err =>
+            logger.error(err)(s"Error when fetching XPosts for user: $username").as(List.empty[XPost])
+          }.flatMap { xPosts =>
+            xPosts.filter { xPost =>
+              searchInformation.exists(searchInfo => xPost.text.toLowerCase.contains(searchInfo.text.toLowerCase))
+            }.traverse { xPost =>
+              searchInformation
+                .find(searchInfo => xPost.text.toLowerCase.contains(searchInfo.text.toLowerCase))
+                .fold {
+                  val defaultSearchInfo = searchInformation.head
+                  logger
+                    .warn(
+                      s"Could not get searchInformation from post: $xPost" +
+                      s"\n\tSearch term: ${xPost.text}. Setting ${defaultSearchInfo.text}"
+                    )
+                    .as(XDataInfo(
                         xPost.id,
                         primaryDAGAddress,
-                        searchInfo.text,
-                        searchInfo.maxPerDay
-                      ).pure[F]
-                    }
+                        defaultSearchInfo.text,
+                        defaultSearchInfo.maxPerDay
+                    ))
+                } { searchInfo =>
+                  XDataInfo(
+                    xPost.id,
+                    primaryDAGAddress,
+                    searchInfo.text,
+                    searchInfo.maxPerDay
+                  ).pure[F]
                 }
             }
-          }.map(_.flatten)
-
-          _ <- logger.info(s"Found ${xPosts.length} x posts")
-
-          filteredXPosts = xPosts.filter { xPost =>
-            !currentPostsIds.contains(xPost.postId) && validateIfAddressCanProceed(xDataSource, searchInformation, xPost.dagAddress, xPost.postId.some)
           }
+        }.map(_.flatten)
 
-          filteredXPostsSearchesAlreadyRewarded = filterAlreadyRewardedSearches(
-            filteredXPosts,
+        _ <- logger.info(s"Found ${xPosts.length} x posts")
+
+        filteredXPosts = xPosts.filter { xPost =>
+          !currentPostsIds.contains(xPost.postId) && validateIfAddressCanProceed(
+            xDataSource,
             searchInformation,
-            xDataSource
+            xPost.dagAddress,
+            xPost.postId.some
           )
+        }
 
-          _ <- logger.info(s"Found ${filteredXPostsSearchesAlreadyRewarded.length} valid x posts: $filteredXPostsSearchesAlreadyRewarded")
-          dataUpdates = filteredXPostsSearchesAlreadyRewarded.foldLeft(List.empty[XUpdate]) { (acc, info) =>
-            acc :+ XUpdate(info.dagAddress, info.searchText.toLowerCase, info.postId)
-          }
-        } yield dataUpdates
-      }
+        filteredXPostsSearchesAlreadyRewarded = filterAlreadyRewardedSearches(
+          filteredXPosts,
+          searchInformation,
+          xDataSource
+        )
+
+        _ <- logger.info(s"Found ${filteredXPostsSearchesAlreadyRewarded.length} valid x posts: $filteredXPostsSearchesAlreadyRewarded")
+        dataUpdates = filteredXPostsSearchesAlreadyRewarded.foldLeft(List.empty[XUpdate]) { (acc, info) =>
+          acc :+ XUpdate(info.dagAddress, info.searchText.toLowerCase, info.postId)
+        }
+      } yield dataUpdates
     }
 }

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/YouTubeFetcher.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/YouTubeFetcher.scala
@@ -106,7 +106,7 @@ class YouTubeFetcher[F[_]: Async: Network](
       searchInfo.minimumDuration.toSeconds
     ).flatMap { videos =>
       users.traverse { user =>
-        videos.filter(_.channelId == user.linkedAccounts.youtube.get.channelId).map { video =>
+        videos.filter(_.channelId == user.linkedAccounts.get.youtube.get.channelId).map { video =>
           YouTubeUpdate(user.primaryDagAddress.get, searchInfo.text.toLowerCase, video)
         }.pure
       }
@@ -190,7 +190,7 @@ object YouTubeFetcher {
               Some(LocalDateTime.now().minusHours(searchInfo.publishedWithinHours.toHours))
             )
 
-            channelIds = filteredLatticeUsers.flatMap(_.linkedAccounts.youtube.map(_.channelId))
+            channelIds = filteredLatticeUsers.flatMap(_.linkedAccounts.get.youtube.map(_.channelId))
             videoIdsFromSearch = youtubeFetcher.filterVideosByChannels(globalSearchResult, channelIds)
             videoIdsFromRewardCandidates = (for {
               existingWallet <- dataSource.existingWallets.values
@@ -224,7 +224,7 @@ object YouTubeFetcher {
     maybeVideo       : Option[VideoDetails]
   ): List[LatticeUser] = latticeUsers.filter { user =>
     user.primaryDagAddress.flatMap { address =>
-      user.linkedAccounts.youtube.map { _ =>
+      user.linkedAccounts.get.youtube.map { _ =>
         validateIfAddressCanProceed(dataSource, searchInformation, address, maybeVideo)
       }
     }.getOrElse(false)

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/YouTubeFetcher.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/YouTubeFetcher.scala
@@ -100,7 +100,7 @@ class YouTubeFetcher[F[_]: Async: Network](
     searchInfo        : YouTubeSearchInfo,
     globalSearchResult: Map[String, List[String]]
   ): F[List[YouTubeUpdate]] = {
-    val channelIds = users.flatMap(_.youtube.map(_.channelId))
+    val channelIds = users.flatMap(_.linkedAccounts.youtube.map(_.channelId))
     val videoIds = filterVideosByChannels(globalSearchResult, channelIds)
 
     fetchVideoDetails(
@@ -109,7 +109,7 @@ class YouTubeFetcher[F[_]: Async: Network](
       searchInfo.minimumViews
     ).flatMap { videos =>
       users.traverse { user =>
-        videos.filter(_.channelId == user.youtube.get.channelId).map { video =>
+        videos.filter(_.channelId == user.linkedAccounts.youtube.get.channelId).map { video =>
           YouTubeUpdate(user.primaryDagAddress.get, searchInfo.text.toLowerCase, video)
         }.pure
       }
@@ -189,7 +189,7 @@ object YouTubeFetcher {
 
         filteredLatticeUsers = latticeUsers.filter { user =>
           user.primaryDagAddress.flatMap { address =>
-            user.youtube.map { _ =>
+            user.linkedAccounts.youtube.map { _ =>
               validateIfAddressCanProceed(dataSource, searchInformation, address, none)
             }
           }.getOrElse(false)

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/Lattice.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/Lattice.scala
@@ -35,8 +35,13 @@ object Lattice {
   case class LatticeUser(
     id               : String,
     primaryDagAddress: Option[Address],
-    youtube          : Option[YouTubeAccount],
-    twitter          : Option[XAccount]
+    linkedAccounts   : LinkedAccounts
+  )
+
+  @derive(encoder, decoder)
+  case class LinkedAccounts(
+    youtube: Option[YouTubeAccount],
+    twitter: Option[XAccount]
   )
 
   @derive(encoder, decoder)

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/Lattice.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/Lattice.scala
@@ -1,0 +1,54 @@
+package org.elpaca_metagraph.shared_data.types
+
+import derevo.circe.magnolia.{decoder, encoder}
+import derevo.derive
+import org.tessellation.schema.address.Address
+import org.tessellation.schema.balance.Amount
+import org.tessellation.schema.epoch.EpochProgress
+
+import scala.collection.immutable.ListMap
+
+object Lattice {
+  trait RewardInfo {
+    def dailyEpochProgress   : EpochProgress
+    def epochProgressToReward: EpochProgress
+    def amountToReward       : Amount
+    def searchText           : String
+    def dailyPostsNumber     : Long
+  }
+
+  trait SocialDataSourceAddress {
+    def addressRewards: ListMap[String, RewardInfo]
+  }
+
+  @derive(encoder, decoder)
+  case class YouTubeAccount(
+    channelId: String
+  )
+
+  @derive(encoder, decoder)
+  case class XAccount(
+    username: String
+  )
+
+  @derive(encoder, decoder)
+  case class LatticeUser(
+    id               : String,
+    primaryDagAddress: Option[Address],
+    youtube          : Option[YouTubeAccount],
+    twitter          : Option[XAccount]
+  )
+
+  @derive(encoder, decoder)
+  case class LatticeUserMeta(
+    total : Long,
+    limit : Long,
+    offset: Long
+  )
+
+  @derive(encoder, decoder)
+  case class LatticeUsersApiResponse(
+    data: List[LatticeUser],
+    meta: Option[LatticeUserMeta]
+  )
+}

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/Lattice.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/Lattice.scala
@@ -35,7 +35,8 @@ object Lattice {
   case class LatticeUser(
     id               : String,
     primaryDagAddress: Option[Address],
-    linkedAccounts   : LinkedAccounts
+    linkedAccounts   : Option[LinkedAccounts],
+    twitter          : Option[XAccount],
   )
 
   @derive(encoder, decoder)

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/X.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/X.scala
@@ -17,7 +17,7 @@ object X {
     amountToReward       : Amount,
     searchText           : String,
     postIds              : List[String],
-    dailyPostsNumber     : Long,
+    dailyPostsNumber     : Long
   ) extends RewardInfo
 
   @derive(encoder, decoder)
@@ -28,11 +28,6 @@ object X {
   object XDataSourceAddress {
     def empty: XDataSourceAddress = XDataSourceAddress(ListMap.empty)
   }
-
-  @derive(encoder, decoder)
-  case class XUser(
-    username: String
-  )
 
   @derive(encoder, decoder)
   case class NoteTweet(

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/X.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/X.scala
@@ -2,9 +2,12 @@ package org.elpaca_metagraph.shared_data.types
 
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
+import org.elpaca_metagraph.shared_data.types.Lattice._
 import org.tessellation.schema.address.Address
 import org.tessellation.schema.balance.Amount
 import org.tessellation.schema.epoch.EpochProgress
+
+import scala.collection.immutable.ListMap
 
 object X {
   @derive(encoder, decoder)
@@ -15,41 +18,20 @@ object X {
     searchText           : String,
     postIds              : List[String],
     dailyPostsNumber     : Long,
-  )
-
+  ) extends RewardInfo
 
   @derive(encoder, decoder)
   case class XDataSourceAddress(
-    addressRewards: Map[String, XRewardInfo]
-  )
+    addressRewards: ListMap[String, XRewardInfo]
+  ) extends SocialDataSourceAddress
 
   object XDataSourceAddress {
-    def empty: XDataSourceAddress = XDataSourceAddress(Map.empty)
+    def empty: XDataSourceAddress = XDataSourceAddress(ListMap.empty)
   }
 
   @derive(encoder, decoder)
   case class XUser(
     username: String
-  )
-
-  @derive(encoder, decoder)
-  case class SourceUser(
-    id               : String,
-    primaryDagAddress: Option[Address],
-    twitter          : Option[XUser]
-  )
-
-  @derive(encoder, decoder)
-  case class SourceUserMeta(
-    total : Long,
-    limit : Long,
-    offset: Long
-  )
-
-  @derive(encoder, decoder)
-  case class SourceUsersApiResponse(
-    data: List[SourceUser],
-    meta: Option[SourceUserMeta]
   )
 
   @derive(encoder, decoder)

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/YouTube.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/YouTube.scala
@@ -2,8 +2,8 @@ package org.elpaca_metagraph.shared_data.types
 
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive
+import org.elpaca_metagraph.shared_data.types.Lattice._
 import org.elpaca_metagraph.shared_data.types.YouTube.YouTubeDataAPI.VideoDetails
-import org.tessellation.schema.address.Address
 import org.tessellation.schema.balance.Amount
 import org.tessellation.schema.epoch.EpochProgress
 
@@ -19,38 +19,12 @@ object YouTube {
     searchText           : String,
     videos               : List[VideoDetails],
     dailyPostsNumber     : Long
-  )
+  ) extends RewardInfo
 
   @derive(encoder, decoder)
   case class YouTubeDataSourceAddress(
     addressRewards: ListMap[String, YouTubeRewardInfo] = ListMap.empty
-  )
-
-  object LatticeClient {
-    @derive(encoder, decoder)
-    case class YouTubeAccount(
-      channelId: String
-    )
-
-    @derive(encoder, decoder)
-    case class LatticeUser(
-      id               : String,
-      primaryDagAddress: Option[Address],
-      youtube          : Option[YouTubeAccount]
-    )
-
-    @derive(encoder, decoder)
-    case class LatticeUserMeta(
-      total : Long,
-      limit : Long,
-      offset: Long
-    )
-
-    @derive(encoder, decoder)
-    case class LatticeUsersApiResponse(
-      data: List[LatticeUser],
-      meta: Option[LatticeUserMeta])
-    }
+  ) extends SocialDataSourceAddress
 
   object YouTubeDataAPI {
     @derive(encoder, decoder)

--- a/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/YouTube.scala
+++ b/modules/shared_data/src/main/scala/org/elpaca_metagraph/shared_data/types/YouTube.scala
@@ -17,8 +17,9 @@ object YouTube {
     epochProgressToReward: EpochProgress,
     amountToReward       : Amount,
     searchText           : String,
+    dailyPostsNumber     : Long,
     videos               : List[VideoDetails],
-    dailyPostsNumber     : Long
+    rewardCandidates     : Option[List[VideoDetails]] = None
   ) extends RewardInfo
 
   @derive(encoder, decoder)
@@ -44,12 +45,13 @@ object YouTube {
       channelId  : String,
       publishedAt: Instant,
       views      : Long,
-      duration   : Long
+      duration   : Long,
+      checkUntil : Option[EpochProgress] = None
     )
 
     @derive(encoder, decoder)
     case class PageInfo(
-      totalResults  : Int
+      totalResults: Int
     )
 
     @derive(encoder, decoder)

--- a/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/UtilsSuite.scala
+++ b/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/UtilsSuite.scala
@@ -1,0 +1,103 @@
+package org.elpaca_metagraph.shared_data
+
+import eu.timepit.refined.types.numeric.NonNegLong
+import org.elpaca_metagraph.shared_data.Utils.isWithinDailyLimit
+import org.elpaca_metagraph.shared_data.app.ApplicationConfig.SearchInfo
+import org.elpaca_metagraph.shared_data.types.Lattice.{RewardInfo, SocialDataSourceAddress}
+import org.scalatest.funsuite.AnyFunSuite
+import org.tessellation.schema.balance.Amount
+import org.tessellation.schema.epoch.EpochProgress
+
+import scala.collection.immutable.ListMap
+
+class UtilsSuite extends AnyFunSuite {
+
+  case class MockRewardInfo(
+    searchText           : String,
+    dailyPostsNumber     : Long,
+    dailyEpochProgress   : EpochProgress = EpochProgress(NonNegLong(20)),
+    epochProgressToReward: EpochProgress = EpochProgress(NonNegLong(20)),
+    amountToReward       : Amount = Amount(NonNegLong(5))
+  ) extends RewardInfo
+
+  case class MockSocialDataSourceAddress(
+    addressRewards: ListMap[String, RewardInfo] = ListMap.empty
+  ) extends SocialDataSourceAddress
+
+  case class MockSearchInfo(
+    text        : String,
+    maxPerDay   : Long,
+    rewardAmount: Amount = Amount(NonNegLong(5))
+  ) extends SearchInfo
+
+  test("isWithinDailyLimit returns true when no rewards match search info") {
+    val searchInfo = MockSearchInfo(text = "test", maxPerDay = 5)
+    val wallet = MockSocialDataSourceAddress()
+
+    assert(isWithinDailyLimit(List(searchInfo), wallet))
+  }
+
+  test("isWithinDailyLimit returns true when rewards dailyPostsNumber is below maxPerDay") {
+    val rewardInfo = MockRewardInfo(
+      searchText = "test",
+      dailyPostsNumber = 3
+    )
+    val searchInfo = MockSearchInfo(text = "test", maxPerDay = 5)
+    val wallet = MockSocialDataSourceAddress(ListMap("test" -> rewardInfo))
+
+    assert(isWithinDailyLimit(List(searchInfo), wallet))
+  }
+
+  test("isWithinDailyLimit returns false when rewards dailyPostsNumber equals maxPerDay") {
+    val rewardInfo = MockRewardInfo(
+      searchText = "test",
+      dailyPostsNumber = 5
+    )
+    val searchInfo = MockSearchInfo(text = "test", maxPerDay = 5)
+    val wallet = MockSocialDataSourceAddress(ListMap("test" -> rewardInfo))
+
+    assert(!isWithinDailyLimit(List(searchInfo), wallet))
+  }
+
+  test("isWithinDailyLimit returns false when rewards dailyPostsNumber exceeds maxPerDay") {
+    val rewardInfo = MockRewardInfo(
+      searchText = "test",
+      dailyPostsNumber = 6
+    )
+    val searchInfo = MockSearchInfo(text = "test", maxPerDay = 5)
+    val wallet = MockSocialDataSourceAddress(ListMap("test" -> rewardInfo))
+
+    assert(!isWithinDailyLimit(List(searchInfo), wallet))
+  }
+
+  test("isWithinDailyLimit handles case-insensitive search text") {
+    val rewardInfo = MockRewardInfo(
+      searchText = "TEST",
+      dailyPostsNumber = 3
+    )
+    val searchInfo = MockSearchInfo(text = "test", maxPerDay = 5)
+    val wallet = MockSocialDataSourceAddress(ListMap("test" -> rewardInfo))
+
+    assert(isWithinDailyLimit(List(searchInfo), wallet))
+  }
+
+  test("isWithinDailyLimit works with multiple search infos") {
+    val rewardInfo1 = MockRewardInfo(
+      searchText = "test1",
+      dailyPostsNumber = 4
+    )
+    val rewardInfo2 = MockRewardInfo(
+      searchText = "test2",
+      dailyPostsNumber = 6
+    )
+
+    val searchInfo1 = MockSearchInfo(text = "test1", maxPerDay = 5)
+    val searchInfo2 = MockSearchInfo(text = "test2", maxPerDay = 5)
+
+    val wallet = MockSocialDataSourceAddress(
+      ListMap("test1" -> rewardInfo1, "test2" -> rewardInfo2)
+    )
+
+    assert(isWithinDailyLimit(List(searchInfo1, searchInfo2), wallet))
+  }
+}

--- a/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/combiners/YouTubeCombinerSuite.scala
+++ b/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/combiners/YouTubeCombinerSuite.scala
@@ -19,11 +19,11 @@ class YouTubeCombinerSuite extends AnyFunSuite with Matchers {
 
   private val mockSearchInfo = ApplicationConfig.YouTubeSearchInfo(
     text = "test-search",
-    rewardAmount = Amount(NonNegLong(10L)),
+    rewardAmount = Amount(NonNegLong(50L)),
     minimumDuration = 60,
     minimumViews = 50,
-    maxPerDay = 3,
-    publishedWithinHours = 24
+    maxPerDay = 1,
+    publishedWithinHours = 3
   )
 
   private val mockConfig = ApplicationConfig(
@@ -49,7 +49,7 @@ class YouTubeCombinerSuite extends AnyFunSuite with Matchers {
 
   private val address = Address("DAG56BtU1j5uCMb5f1QxZ5oxfBhpUeYucRGygfEa")
   private val currentEpoch = EpochProgress(NonNegLong(5L))
-  private val olderEpoch = EpochProgress(NonNegLong(4L))
+  private val previousEpoch = EpochProgress(NonNegLong(4L))
 
   test("updateYoutubeRewardsOlderThanOneDay should reset daily posts on a new day") {
     val initialState: Map[DataSourceType, YouTubeDataSource] = Map(
@@ -58,12 +58,12 @@ class YouTubeCombinerSuite extends AnyFunSuite with Matchers {
           address -> YouTubeDataSourceAddress(
             addressRewards = ListMap(
               "test-search" -> YouTubeRewardInfo(
-                dailyEpochProgress = olderEpoch,
-                epochProgressToReward = olderEpoch,
-                amountToReward = toTokenAmountFormat(20),
+                dailyEpochProgress = previousEpoch,
+                epochProgressToReward = previousEpoch,
+                amountToReward = toTokenAmountFormat(50),
                 searchText = "test-search",
                 videos = List(),
-                dailyPostsNumber = 2
+                dailyPostsNumber = 0
               )
             )
           )
@@ -78,8 +78,8 @@ class YouTubeCombinerSuite extends AnyFunSuite with Matchers {
       .existingWallets(address)
       .addressRewards("test-search")
 
-    rewards.dailyPostsNumber shouldBe 2 //0
-    rewards.dailyEpochProgress shouldBe olderEpoch //currentEpoch
+    rewards.dailyPostsNumber shouldBe 0
+    rewards.dailyEpochProgress shouldBe previousEpoch
   }
 
   test("updateYoutubeRewardsOlderThanOneDay should not reset rewards if on the same day") {
@@ -135,7 +135,7 @@ class YouTubeCombinerSuite extends AnyFunSuite with Matchers {
 
     rewards.dailyPostsNumber shouldBe 1
     rewards.epochProgressToReward shouldBe currentEpoch
-    rewards.amountToReward shouldBe toTokenAmountFormat(10)
+    rewards.amountToReward shouldBe toTokenAmountFormat(50)
   }
 
   test("updateYouTubeState should update existing rewards if criteria are met") {
@@ -147,7 +147,7 @@ class YouTubeCombinerSuite extends AnyFunSuite with Matchers {
               "test-search" -> YouTubeRewardInfo(
                 dailyEpochProgress = currentEpoch,
                 epochProgressToReward = currentEpoch,
-                amountToReward = toTokenAmountFormat(10),
+                amountToReward = toTokenAmountFormat(50),
                 searchText = "test-search",
                 videos = List(),
                 dailyPostsNumber = 1
@@ -173,8 +173,8 @@ class YouTubeCombinerSuite extends AnyFunSuite with Matchers {
 
     val rewards = updatedState.existingWallets(address).addressRewards("test-search")
 
-    rewards.dailyPostsNumber shouldBe 2
-    rewards.amountToReward shouldBe toTokenAmountFormat(20)
+    rewards.dailyPostsNumber shouldBe 1
+    rewards.amountToReward shouldBe toTokenAmountFormat(50)
   }
 
   test("updateYouTubeState should not update rewards if daily limit is exceeded") {

--- a/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/combiners/YouTubeCombinerSuite.scala
+++ b/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/combiners/YouTubeCombinerSuite.scala
@@ -2,7 +2,7 @@ package org.elpaca_metagraph.shared_data.combiners
 
 import eu.timepit.refined.auto._
 import eu.timepit.refined.types.numeric.NonNegLong
-import org.elpaca_metagraph.shared_data.Utils.{epochProgressOneDay, toTokenAmountFormat}
+import org.elpaca_metagraph.shared_data.Utils.toTokenAmountFormat
 import org.elpaca_metagraph.shared_data.app.ApplicationConfig
 import org.elpaca_metagraph.shared_data.types.DataUpdates.YouTubeUpdate
 import org.elpaca_metagraph.shared_data.types.States.{DataSourceType, YouTubeDataSource}
@@ -277,8 +277,6 @@ class YouTubeCombinerSuite extends AnyFunSuite with Matchers {
     rewards.amountToReward shouldBe toTokenAmountFormat(0)
     // Once the update video doesn't meet criteria this time, it shall be stacked in rewardCandidates
     rewards.rewardCandidates.get.head.id shouldBe "test-id"
-
-    println(rewards)
 
     // Same video sent on retrial
     val newUpdatedState = YouTubeCombiner.updateYouTubeState(

--- a/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/FetcherSuite.scala
+++ b/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/FetcherSuite.scala
@@ -1,0 +1,25 @@
+package org.elpaca_metagraph.shared_data.daemons.fetcher
+
+import cats.effect.IO
+import cats.syntax.all._
+import org.elpaca_metagraph.shared_data.types.Refined.ApiUrl
+import org.tessellation.schema.address.Address
+import eu.timepit.refined.auto._
+import org.http4s.client.Client
+import org.http4s.{HttpRoutes, Response, Uri}
+import org.typelevel.log4cats.SelfAwareStructuredLogger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+trait FetcherSuite {
+  implicit val logger: SelfAwareStructuredLogger[IO] = Slf4jLogger.getLoggerFromClass(this.getClass)
+
+  protected val baseUrl: ApiUrl = ApiUrl.unsafeFrom("http://localhost:8080")
+  protected val dagAddress1: Address = Address("DAG56BtU1j5uCMb5f1QxZ5oxfBhpUeYucRGygfEa")
+  protected val dagAddress2: Address = Address("DAG45ZLcgmQeRHY3oV2ZJACrFUjEZwqeXKSfZc75")
+
+  def mockClient(responses: Map[Uri, Response[IO]]): Client[IO] = Client.fromHttpApp(HttpRoutes.of[IO] {
+    case req if responses.contains(req.uri) =>
+      responses(req.uri).pure[IO]
+  }.orNotFound)
+
+}

--- a/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/FetcherSuite.scala
+++ b/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/FetcherSuite.scala
@@ -16,6 +16,7 @@ trait FetcherSuite {
   protected val baseUrl: ApiUrl = ApiUrl.unsafeFrom("http://localhost:8080")
   protected val dagAddress1: Address = Address("DAG56BtU1j5uCMb5f1QxZ5oxfBhpUeYucRGygfEa")
   protected val dagAddress2: Address = Address("DAG45ZLcgmQeRHY3oV2ZJACrFUjEZwqeXKSfZc75")
+  protected val dagAddress3: Address = Address("DAG4J3i4K87evc71ti3aEcSKx8AUR5GhPy3EysiM")
 
   def mockClient(responses: Map[Uri, Response[IO]]): Client[IO] = Client.fromHttpApp(HttpRoutes.of[IO] {
     case req if responses.contains(req.uri) =>

--- a/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/LatticeFetcherSuite.scala
+++ b/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/LatticeFetcherSuite.scala
@@ -18,11 +18,11 @@ import scala.concurrent.duration._
 class LatticeFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
   private val latticeUsersResponse = LatticeUsersApiResponse(
     data = List(
-      LatticeUser("user1", Some(dagAddress1), Some(YouTubeAccount("channel1")), None),
-      LatticeUser("user2", None, Some(YouTubeAccount("channel2")), None),
-      LatticeUser("user3", Some(dagAddress1), None, Some(XAccount("account1"))),
-      LatticeUser("user4", None, None, Some(XAccount("account2"))),
-      LatticeUser("user5", Some(dagAddress2), None, None)
+      LatticeUser("user1", Some(dagAddress1), LinkedAccounts(Some(YouTubeAccount("channel1")), None)),
+      LatticeUser("user2", None, LinkedAccounts(Some(YouTubeAccount("channel2")), None)),
+      LatticeUser("user3", Some(dagAddress1), LinkedAccounts(None, Some(XAccount("account1")))),
+      LatticeUser("user4", None, LinkedAccounts(None, Some(XAccount("account2")))),
+      LatticeUser("user5", Some(dagAddress2), LinkedAccounts(None, None))
     ),
     meta = Some(LatticeUserMeta(total = 5, limit = 100, offset = 0))
   )
@@ -37,7 +37,7 @@ class LatticeFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
 
     users should have size 1
     users.head.primaryDagAddress shouldBe Some(dagAddress1)
-    users.head.youtube.map(_.channelId) shouldBe Some("channel1")
+    users.head.linkedAccounts.youtube.map(_.channelId) shouldBe Some("channel1")
   }
 
   test("fetchLatticeUsersWithXAccount should return only valid users with X accounts") {
@@ -50,7 +50,7 @@ class LatticeFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
 
     users should have size 1
     users.head.primaryDagAddress shouldBe Some(dagAddress1)
-    users.head.twitter.map(_.username) shouldBe Some("account1")
+    users.head.linkedAccounts.twitter.map(_.username) shouldBe Some("account1")
   }
 
   test("fetchLatticeUsers should handle API errors gracefully") {
@@ -78,7 +78,8 @@ class LatticeFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
     val paginatedResponses = (0 until totalPages).map { page =>
       val offset = page * pageSize
       val response = LatticeUsersApiResponse(
-        data = List.fill(pageSize)(LatticeUser(s"user$offset", Some(dagAddress1), Some(YouTubeAccount(s"channel$offset")), None)),
+        data = List
+          .fill(pageSize)(LatticeUser(s"user$offset", Some(dagAddress1), LinkedAccounts(Some(YouTubeAccount(s"channel$offset")), None))),
         meta = Some(LatticeUserMeta(total = totalUsers.toLong, limit = pageSize.toLong, offset = offset.toLong))
       )
 

--- a/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/LatticeFetcherSuite.scala
+++ b/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/LatticeFetcherSuite.scala
@@ -1,0 +1,165 @@
+package org.elpaca_metagraph.shared_data.daemons.fetcher
+
+import cats.effect._
+import cats.effect.testkit.TestControl
+import cats.syntax.all._
+import io.circe.syntax._
+import org.elpaca_metagraph.shared_data.types.Lattice._
+import org.http4s._
+import org.http4s.circe._
+import org.http4s.client.Client
+import org.http4s.implicits._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration._
+
+class LatticeFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
+  private val latticeUsersResponse = LatticeUsersApiResponse(
+    data = List(
+      LatticeUser("user1", Some(dagAddress1), Some(YouTubeAccount("channel1")), None),
+      LatticeUser("user2", None, Some(YouTubeAccount("channel2")), None),
+      LatticeUser("user3", Some(dagAddress1), None, Some(XAccount("account1"))),
+      LatticeUser("user4", None, None, Some(XAccount("account2"))),
+      LatticeUser("user5", Some(dagAddress2), None, None)
+    ),
+    meta = Some(LatticeUserMeta(total = 5, limit = 100, offset = 0))
+  )
+
+  test("fetchLatticeUsers should return only valid users with YouTube accounts") {
+    implicit val client: Client[IO] = mockClient(Map(
+      Uri.unsafeFromString(baseUrl.toString()) -> Response[IO](Status.Ok).withEntity(latticeUsersResponse.asJson)
+    ))
+
+    val fetcher = new LatticeFetcher[IO](baseUrl)
+
+    val result = TestControl.execute {
+      for {
+        users <- fetcher.fetchLatticeUsersWithYouTubeAccount()
+        _ <- IO {
+          users should have size 1
+          users.head.primaryDagAddress shouldBe Some(dagAddress1)
+          users.head.youtube.map(_.channelId) shouldBe Some("channel1")
+        }
+      } yield ()
+    }
+
+    result.flatMap(_.tickAll)
+  }
+
+  test("fetchLatticeUsers should return only valid users with X accounts") {
+    implicit val client: Client[IO] = mockClient(Map(
+      Uri.unsafeFromString(baseUrl.toString()) -> Response[IO](Status.Ok).withEntity(latticeUsersResponse.asJson)
+    ))
+
+    val fetcher = new LatticeFetcher[IO](baseUrl)
+
+    val result = TestControl.execute {
+      for {
+        users <- fetcher.fetchLatticeUsersWithYouTubeAccount()
+        _ <- IO {
+          users should have size 1
+          users.head.primaryDagAddress shouldBe Some(dagAddress1)
+          users.head.twitter.map(_.username) shouldBe Some("account1")
+        }
+      } yield ()
+    }
+
+    result.flatMap(_.tickAll)
+  }
+
+  test("fetchLatticeUsers should handle API errors gracefully") {
+    implicit val client: Client[IO] = mockClient(Map(
+      Uri.unsafeFromString(baseUrl.toString()) -> Response[IO](Status.InternalServerError)
+    ))
+
+    val fetcher = new LatticeFetcher[IO](baseUrl)
+
+    val result = TestControl.execute {
+      fetcher.fetchLatticeUsers().attempt.map {
+        case Left(error) => error shouldBe a[Throwable]
+        case Right(_)    => fail("Expected an error but got success")
+      }
+    }
+
+    result.flatMap(_.tickAll)
+  }
+
+  test("fetchLatticeUsers should handle large datasets") {
+    val largeResponse = LatticeUsersApiResponse(
+      data = List.fill(1000)(LatticeUser("user", Some(dagAddress1), Some(YouTubeAccount("channel1")), None)),
+      meta = Some(LatticeUserMeta(total = 1000, limit = 100, offset = 0))
+    )
+
+    implicit val client: Client[IO] = mockClient(Map(
+      Uri.unsafeFromString(baseUrl.toString()) -> Response[IO](Status.Ok).withEntity(largeResponse.asJson)
+    ))
+
+    val fetcher = new LatticeFetcher[IO](baseUrl)
+
+    val result = TestControl.execute {
+      fetcher.fetchLatticeUsers().map { users =>
+        users should have size 1000
+      }
+    }
+
+    result.flatMap(_.tickAll)
+  }
+
+  test("YouTubeFetcher should handle rate-limiting gracefully") {
+    val rateLimitResponse = Response[IO](Status.TooManyRequests)
+
+    implicit val client: Client[IO] = mockClient(Map(
+      Uri.unsafeFromString(baseUrl.toString()) -> rateLimitResponse
+    ))
+
+    val fetcher = new LatticeFetcher[IO](baseUrl)
+
+    val result = TestControl.execute {
+      fetcher.fetchLatticeUsers().attempt.map {
+        case Left(error) => error shouldBe a[Throwable]
+        case Right(_)    => fail("Expected an error but got success")
+      }
+    }
+
+    result.flatMap(_.tickAll)
+  }
+
+  test("YouTubeFetcher should log API responses and errors") {
+    val response = Response[IO](Status.Ok).withEntity(latticeUsersResponse.asJson)
+
+    implicit val client: Client[IO] = mockClient(Map(
+      Uri.unsafeFromString(baseUrl.toString()) -> response
+    ))
+
+    val fetcher = new LatticeFetcher[IO](baseUrl)
+
+    val result = TestControl.execute {
+      fetcher.fetchLatticeUsers().flatMap { _ =>
+        logger.info("API responded successfully")
+      }
+    }
+
+    result.flatMap(_.tickAll)
+  }
+
+  test("YouTubeFetcher should handle API timeouts") {
+    val delayedResponse = IO.sleep(5.seconds) *> Response[IO](Status.Ok).withEntity(latticeUsersResponse.asJson).pure[IO]
+
+    implicit val client: Client[IO] = Client.fromHttpApp(HttpRoutes.of[IO] {
+      case _ => delayedResponse
+    }.orNotFound)
+
+    val fetcher = new LatticeFetcher[IO](baseUrl)
+
+    val result = TestControl.execute {
+      fetcher.fetchLatticeUsers().attempt.map {
+        case Left(error) => error shouldBe a[Throwable]
+        case Right(_)    => fail("Expected an error but got success")
+      }
+    }
+
+    result.flatMap(_.tickAll)
+  }
+
+}

--- a/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/XFetcherSuite.scala
+++ b/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/XFetcherSuite.scala
@@ -1,0 +1,107 @@
+package org.elpaca_metagraph.shared_data.daemons.fetcher
+
+import cats.effect._
+import cats.effect.testkit.TestControl
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.numeric.NonNegLong
+import io.circe.syntax._
+import org.elpaca_metagraph.shared_data.Utils
+import org.elpaca_metagraph.shared_data.app.ApplicationConfig
+import org.elpaca_metagraph.shared_data.types.Lattice.{LatticeUser, XAccount}
+import org.elpaca_metagraph.shared_data.types.States.XDataSource
+import org.elpaca_metagraph.shared_data.types.X._
+import org.http4s._
+import org.http4s.circe._
+import org.http4s.client.Client
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.tessellation.schema.address.Address
+import org.tessellation.schema.epoch.EpochProgress
+
+import java.time.LocalDateTime
+import scala.collection.immutable.ListMap
+
+class XFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
+
+  private val searchInfo = List(ApplicationConfig.XSearchInfo("test", Utils.toTokenAmountFormat(5), maxPerDay = 1))
+  private val post1 = XPost("post1", "dag", Some(NoteTweet("Some note about dag")))
+  private val post2 = XPost("post2", "dag", Some(NoteTweet("Some other note about dag")))
+  private val post3 = XPost("post3", "americasblockchain", Some(NoteTweet("Some note about americasblockchain")))
+  private val post4 = XPost("post4", "americasblockchain", Some(NoteTweet("Some other note about americasblockchain")))
+  private val user1 = createUser(1, dagAddress1)
+  private val user2 = createUser(2, dagAddress2)
+  private val user3 = createUser(3, Address("DAG7B91BBsVAyoKsWkwK4AvALHuzYSyxxFPSJ2jY"))
+  private val user4 = createUser(3, Address("DAG6aewPmSWoyRNZx4QgyTBbQxwsGRR1SJN1peQS"))
+  private val users = List(user1, user2, user3, user4)
+  private val epochProgress = EpochProgress(NonNegLong(1))
+  private val xRewardInfo1 = XRewardInfo(epochProgress, epochProgress, Utils.toTokenAmountFormat(1), "dag", List("post1"), 1)
+  private val xPostsResponse = XApiResponse(
+    data = Some(List(post1, post2, post3, post4)),
+    meta = XApiResponseMetadata(4)
+  )
+
+  private def createUser(i: Int, dagAddress: Address): LatticeUser =
+    LatticeUser(s"user$i", Some(dagAddress), None, Some(XAccount(s"account$i")))
+
+  test("fetchXPosts should fetch and filter posts correctly") {
+    implicit val client: Client[IO] = mockClient(Map(
+      Uri.unsafeFromString(baseUrl.toString()) -> Response[IO](Status.Ok).withEntity(xPostsResponse.asJson)
+    ))
+
+    val fetcher = new XFetcher[IO](
+      apiUrl = baseUrl,
+      xApiConsumerKey = "key",
+      xApiConsumerSecret = "secret",
+      xApiAccessToken = "token",
+      xApiAccessSecret = "secret"
+    )
+
+    val result = TestControl.execute {
+      for {
+        posts <- fetcher.fetchXPosts(
+          username = "user1",
+          searchText = "dag",
+          currentDateTime = LocalDateTime.now()
+        )
+        _ <- IO {
+          posts should have size 2
+          posts.map(_.id) should contain theSameElementsAs List("post1", "post2")
+        }
+      } yield ()
+    }
+
+    result.flatMap(_.tickAll)
+  }
+
+  test("splitUsersIntoGroups should divide users correctly") {
+    val result = XFetcher.splitUsersIntoGroups(users)
+    result should have size 4
+    result.flatten should have size 4
+  }
+
+  test("validateIfAddressCanProceed should respect daily limits") {
+    val mockDataSource = XDataSource(Map(
+      dagAddress1 -> XDataSourceAddress(ListMap("dag" -> xRewardInfo1))
+    ))
+
+    val result = XFetcher.validateIfAddressCanProceed(mockDataSource, searchInfo, dagAddress1, Some("post1"))
+
+    result shouldBe true
+  }
+
+  test("filterAlreadyRewardedSearches should filter out rewarded posts") {
+    val xPosts = List(
+      XDataInfo("post1", dagAddress1, "dag", 1),
+      XDataInfo("post2", dagAddress2, "dag", 1)
+    )
+
+    val mockDataSource = XDataSource(Map(
+      dagAddress1 -> XDataSourceAddress(ListMap("dag" -> xRewardInfo1))
+    ))
+
+    val result = XFetcher.filterAlreadyRewardedSearches(xPosts, searchInfo, mockDataSource)
+
+    result should have size 1
+    result.head.postId shouldBe "post2"
+  }
+}

--- a/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/XFetcherSuite.scala
+++ b/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/XFetcherSuite.scala
@@ -1,11 +1,12 @@
 package org.elpaca_metagraph.shared_data.daemons.fetcher
 
 import cats.effect._
-import cats.effect.testkit.TestControl
+import cats.effect.unsafe.implicits.global
 import eu.timepit.refined.auto._
 import eu.timepit.refined.types.numeric.NonNegLong
 import io.circe.syntax._
 import org.elpaca_metagraph.shared_data.Utils
+import org.elpaca_metagraph.shared_data.Utils.timeRangeFromDayStartTillNowFormatted
 import org.elpaca_metagraph.shared_data.app.ApplicationConfig
 import org.elpaca_metagraph.shared_data.types.Lattice.{LatticeUser, XAccount}
 import org.elpaca_metagraph.shared_data.types.States.XDataSource
@@ -23,30 +24,67 @@ import scala.collection.immutable.ListMap
 
 class XFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
 
-  private val searchInfo = List(ApplicationConfig.XSearchInfo("test", Utils.toTokenAmountFormat(5), maxPerDay = 1))
-  private val post1 = XPost("post1", "dag", Some(NoteTweet("Some note about dag")))
-  private val post2 = XPost("post2", "dag", Some(NoteTweet("Some other note about dag")))
-  private val post3 = XPost("post3", "americasblockchain", Some(NoteTweet("Some note about americasblockchain")))
-  private val post4 = XPost("post4", "americasblockchain", Some(NoteTweet("Some other note about americasblockchain")))
+  private val DAG = "#$dag"
+  private val AMERICASBLOCKCHAIN = "#americasblockchain"
+  private val searchInfo = List(
+    ApplicationConfig.XSearchInfo(DAG, Utils.toTokenAmountFormat(5), maxPerDay = 1),
+    ApplicationConfig.XSearchInfo(AMERICASBLOCKCHAIN, Utils.toTokenAmountFormat(5), maxPerDay = 1)
+  )
+  private val post1 = XPost("post1", s"Some note about $DAG", None)
+  private val post2 = XPost("post2", s"Some other note about ${DAG.toUpperCase()}", None)
+  private val post3 = XPost("post3", s"Some note about $AMERICASBLOCKCHAIN", None)
+  private val post4 = XPost("post4", s"Some other note about ${AMERICASBLOCKCHAIN.toUpperCase()}", None)
+  private val post5 = XPost("post5", s"A post with both $DAG and $AMERICASBLOCKCHAIN tags", None)
+  private val post6 = XPost("post6", s"Another post with both $AMERICASBLOCKCHAIN and $DAG tags", None)
+  private val post7 = XPost("post7", "A random post without any search term in it", None)
+  private val post8 = XPost("post8", "Another random post without any search term in it", None)
+  private val posts = List(post1, post2, post3, post4, post5, post6, post7, post8)
   private val user1 = createUser(1, dagAddress1)
   private val user2 = createUser(2, dagAddress2)
   private val user3 = createUser(3, Address("DAG7B91BBsVAyoKsWkwK4AvALHuzYSyxxFPSJ2jY"))
   private val user4 = createUser(3, Address("DAG6aewPmSWoyRNZx4QgyTBbQxwsGRR1SJN1peQS"))
   private val users = List(user1, user2, user3, user4)
   private val epochProgress = EpochProgress(NonNegLong(1))
-  private val xRewardInfo1 = XRewardInfo(epochProgress, epochProgress, Utils.toTokenAmountFormat(1), "dag", List("post1"), 1)
+  private val xRewardInfo1 = XRewardInfo(epochProgress, epochProgress, Utils.toTokenAmountFormat(1), DAG, List(post1.id), 1)
+  private val xRewardInfo2 = XRewardInfo(epochProgress, epochProgress, Utils.toTokenAmountFormat(1), DAG, List(post5.id), 1)
   private val xPostsResponse = XApiResponse(
-    data = Some(List(post1, post2, post3, post4)),
+    data = Some(posts),
+    meta = XApiResponseMetadata(4)
+  )
+  private val xDagPostsResponse = XApiResponse(
+    data = Some(posts.filter(_.text.toLowerCase().contains(DAG))),
+    meta = XApiResponseMetadata(4)
+  )
+  private val xABPostsResponse = XApiResponse(
+    data = Some(posts.filter(_.text.toLowerCase().contains(AMERICASBLOCKCHAIN))),
     meta = XApiResponseMetadata(4)
   )
 
   private def createUser(i: Int, dagAddress: Address): LatticeUser =
     LatticeUser(s"user$i", Some(dagAddress), None, Some(XAccount(s"account$i")))
 
-  test("fetchXPosts should fetch and filter posts correctly") {
-    implicit val client: Client[IO] = mockClient(Map(
-      Uri.unsafeFromString(baseUrl.toString()) -> Response[IO](Status.Ok).withEntity(xPostsResponse.asJson)
-    ))
+  private def buildUriForUser(
+    username: String,
+    searchText: String,
+    currentDate: LocalDateTime,
+    expectedResponse: XApiResponse = xPostsResponse
+  ): Map[Uri, Response[IO]] = {
+    val (startTime, endTime) = timeRangeFromDayStartTillNowFormatted(currentDate)
+
+    Map(Uri
+      .unsafeFromString(baseUrl.toString())
+      .withQueryParam("query", s"from:$username (\"$searchText\") -is:reply -is:retweet")
+      .withQueryParam("start_time", s"$startTime")
+      .withQueryParam("end_time", s"$endTime")
+      .withQueryParam("tweet.fields", "note_tweet")
+      -> Response[IO](Status.Ok).withEntity(expectedResponse.asJson))
+  }
+
+  test("fetchXPosts should fetch and filter posts with #$dag correctly") {
+    val searchText = DAG
+    val currentDate = LocalDateTime.now()
+
+    implicit val client: Client[IO] = mockClient(buildUriForUser(user1.id, searchText, currentDate, xDagPostsResponse))
 
     val fetcher = new XFetcher[IO](
       apiUrl = baseUrl,
@@ -56,21 +94,28 @@ class XFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
       xApiAccessSecret = "secret"
     )
 
-    val result = TestControl.execute {
-      for {
-        posts <- fetcher.fetchXPosts(
-          username = "user1",
-          searchText = "dag",
-          currentDateTime = LocalDateTime.now()
-        )
-        _ <- IO {
-          posts should have size 2
-          posts.map(_.id) should contain theSameElementsAs List("post1", "post2")
-        }
-      } yield ()
-    }
+    val posts = fetcher.fetchXPosts(user1.id, searchText, currentDate).unsafeRunSync()
+    posts should have size 4
+    posts.map(_.id) should contain theSameElementsAs List(post1.id, post2.id, post5.id, post6.id)
+  }
 
-    result.flatMap(_.tickAll)
+  test("fetchXPosts should fetch and filter posts with #americasblockchain correctly") {
+    val searchText = AMERICASBLOCKCHAIN
+    val currentDate = LocalDateTime.now()
+
+    implicit val client: Client[IO] = mockClient(buildUriForUser(user1.id, searchText, currentDate, xABPostsResponse))
+
+    val fetcher = new XFetcher[IO](
+      apiUrl = baseUrl,
+      xApiConsumerKey = "key",
+      xApiConsumerSecret = "secret",
+      xApiAccessToken = "token",
+      xApiAccessSecret = "secret"
+    )
+
+    val posts = fetcher.fetchXPosts(user1.id, searchText, currentDate).unsafeRunSync()
+    posts should have size 4
+    posts.map(_.id) should contain theSameElementsAs List(post3.id, post4.id, post5.id, post6.id)
   }
 
   test("splitUsersIntoGroups should divide users correctly") {
@@ -79,29 +124,45 @@ class XFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
     result.flatten should have size 4
   }
 
-  test("validateIfAddressCanProceed should respect daily limits") {
-    val mockDataSource = XDataSource(Map(
-      dagAddress1 -> XDataSourceAddress(ListMap("dag" -> xRewardInfo1))
-    ))
-
-    val result = XFetcher.validateIfAddressCanProceed(mockDataSource, searchInfo, dagAddress1, Some("post1"))
-
-    result shouldBe true
-  }
-
-  test("filterAlreadyRewardedSearches should filter out rewarded posts") {
+  test("filterXPosts should filter out posts with same tag regardless if it's in uppercase or lowercase") {
     val xPosts = List(
-      XDataInfo("post1", dagAddress1, "dag", 1),
-      XDataInfo("post2", dagAddress2, "dag", 1)
+      XDataInfo(post1.id, dagAddress1, DAG, 1), // lowercase, already rewarded
+      XDataInfo(post2.id, dagAddress1, DAG, 1)  // uppercase
     )
 
     val mockDataSource = XDataSource(Map(
-      dagAddress1 -> XDataSourceAddress(ListMap("dag" -> xRewardInfo1))
+      dagAddress1 -> XDataSourceAddress(ListMap(DAG -> xRewardInfo1))
     ))
 
-    val result = XFetcher.filterAlreadyRewardedSearches(xPosts, searchInfo, mockDataSource)
+    val result = XFetcher.filterXPosts(xPosts, XFetcher.currentPostsIds(mockDataSource), mockDataSource, searchInfo)
+    result should have size 0 // post1 and post2 have the same tag and post1 has already been rewarded
+  }
+
+  test("validateIfAddressCanProceed should verify if post has already been rewarded") {
+    val mockDataSource = XDataSource(Map(
+      dagAddress1 -> XDataSourceAddress(ListMap(DAG -> xRewardInfo1))
+    ))
+
+    val case1 = XFetcher.validateIfAddressCanProceed(mockDataSource, searchInfo, dagAddress1, Some(post1.id))
+    val case2 = XFetcher.validateIfAddressCanProceed(mockDataSource, searchInfo, dagAddress1, Some(post2.id))
+
+    case1 shouldBe false
+    case2 shouldBe true
+  }
+
+  test("removeAlreadyRewardedSearches should filter out posts with tags that have already reached daily limit") {
+    val xPosts = List(
+      XDataInfo(post3.id, dagAddress1, AMERICASBLOCKCHAIN, 1),
+      XDataInfo(post5.id, dagAddress1, DAG, 1)
+    )
+
+    val mockDataSource = XDataSource(Map(
+      dagAddress1 -> XDataSourceAddress(ListMap(DAG -> xRewardInfo2))
+    ))
+
+    val result = XFetcher.removeAlreadyRewardedSearches(xPosts, searchInfo, mockDataSource)
 
     result should have size 1
-    result.head.postId shouldBe "post2"
+    result.map(_.postId) should contain theSameElementsAs List(post3.id)
   }
 }

--- a/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/XFetcherSuite.scala
+++ b/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/XFetcherSuite.scala
@@ -8,7 +8,7 @@ import io.circe.syntax._
 import org.elpaca_metagraph.shared_data.Utils
 import org.elpaca_metagraph.shared_data.Utils.timeRangeFromDayStartTillNowFormatted
 import org.elpaca_metagraph.shared_data.app.ApplicationConfig
-import org.elpaca_metagraph.shared_data.types.Lattice.{LatticeUser, XAccount}
+import org.elpaca_metagraph.shared_data.types.Lattice.{LatticeUser, LinkedAccounts, XAccount}
 import org.elpaca_metagraph.shared_data.types.States.XDataSource
 import org.elpaca_metagraph.shared_data.types.X._
 import org.http4s._
@@ -60,8 +60,16 @@ class XFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
     meta = XApiResponseMetadata(4)
   )
 
+  private def getXFetcherInstance()(implicit client: Client[IO]) = new XFetcher[IO](
+    apiUrl = baseUrl,
+    xApiConsumerKey = "key",
+    xApiConsumerSecret = "secret",
+    xApiAccessToken = "token",
+    xApiAccessSecret = "secret"
+  )
+
   private def createUser(i: Int, dagAddress: Address): LatticeUser =
-    LatticeUser(s"user$i", Some(dagAddress), None, Some(XAccount(s"account$i")))
+    LatticeUser(s"user$i", Some(dagAddress), LinkedAccounts(None, Some(XAccount(s"account$i"))))
 
   private def buildUriForUser(
     username: String,
@@ -86,13 +94,7 @@ class XFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
 
     implicit val client: Client[IO] = mockClient(buildUriForUser(user1.id, searchText, currentDate, xDagPostsResponse))
 
-    val fetcher = new XFetcher[IO](
-      apiUrl = baseUrl,
-      xApiConsumerKey = "key",
-      xApiConsumerSecret = "secret",
-      xApiAccessToken = "token",
-      xApiAccessSecret = "secret"
-    )
+    val fetcher = getXFetcherInstance()
 
     val posts = fetcher.fetchXPosts(user1.id, searchText, currentDate).unsafeRunSync()
     posts should have size 4
@@ -105,13 +107,7 @@ class XFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
 
     implicit val client: Client[IO] = mockClient(buildUriForUser(user1.id, searchText, currentDate, xABPostsResponse))
 
-    val fetcher = new XFetcher[IO](
-      apiUrl = baseUrl,
-      xApiConsumerKey = "key",
-      xApiConsumerSecret = "secret",
-      xApiAccessToken = "token",
-      xApiAccessSecret = "secret"
-    )
+    val fetcher = getXFetcherInstance()
 
     val posts = fetcher.fetchXPosts(user1.id, searchText, currentDate).unsafeRunSync()
     posts should have size 4

--- a/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/XFetcherSuite.scala
+++ b/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/XFetcherSuite.scala
@@ -46,10 +46,6 @@ class XFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
   private val users = List(user1, user2, user3, user4)
   private val epochProgress = EpochProgress(NonNegLong(1))
   private val xRewardInfo1 = XRewardInfo(epochProgress, epochProgress, Utils.toTokenAmountFormat(1), DAG, List(post1.id), 1)
-  private val xPostsResponse = XApiResponse(
-    data = Some(posts),
-    meta = XApiResponseMetadata(4)
-  )
   private val xDagPostsResponse = XApiResponse(
     data = Some(posts.filter(_.text.toLowerCase().contains(DAG))),
     meta = XApiResponseMetadata(4)
@@ -68,13 +64,13 @@ class XFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
   )
 
   private def createUser(i: Int, dagAddress: Address): LatticeUser =
-    LatticeUser(s"user$i", Some(dagAddress), LinkedAccounts(None, Some(XAccount(s"account$i"))))
+    LatticeUser(s"user$i", Some(dagAddress), Some(LinkedAccounts(None, Some(XAccount(s"account$i")))), None)
 
   private def buildUriForUser(
     username: String,
     searchText: String,
     currentDate: LocalDateTime,
-    expectedResponse: XApiResponse = xPostsResponse
+    expectedResponse: XApiResponse
   ): Map[Uri, Response[IO]] = {
     val (startTime, endTime) = timeRangeFromDayStartTillNowFormatted(currentDate)
 

--- a/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/YouTubeFetcherSuite.scala
+++ b/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/YouTubeFetcherSuite.scala
@@ -1,7 +1,7 @@
 package org.elpaca_metagraph.shared_data.daemons.fetcher
 
 import cats.effect._
-import cats.effect.testkit.TestControl
+import cats.effect.unsafe.implicits.global
 import io.circe.syntax._
 import org.elpaca_metagraph.shared_data.Utils.toTokenAmountFormat
 import org.elpaca_metagraph.shared_data.app.ApplicationConfig
@@ -14,6 +14,8 @@ import org.http4s.implicits._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import java.time.Instant
 
 class YouTubeFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
@@ -42,41 +44,50 @@ class YouTubeFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
       VideoResponse(
         "video1",
         VideoSnippetResponse("channel1", Instant.now()),
-        VideoStatisticsResponse(Some(500)),
+        VideoStatisticsResponse(Some(50)),
         VideoContentDetailsResponse("PT3M")
       ),
       VideoResponse(
         "video2",
         VideoSnippetResponse("channel2", Instant.now()),
-        VideoStatisticsResponse(Some(50)),
+        VideoStatisticsResponse(Some(49)),
         VideoContentDetailsResponse("PT2M")
       )
     )
   )
 
+  private def buildVideosDetailsUri(videoIds: List[String]): Uri =
+    Uri
+      .unsafeFromString(s"$baseUrl/videos")
+      .withQueryParam("key", apiKey)
+      .withQueryParam("id", videoIds.mkString(","))
+      .withQueryParam("part", "snippet,contentDetails,statistics")
+
+  private def buildSearchUri(searchQuery: String): Uri =
+    Uri
+      .unsafeFromString(s"$baseUrl/search")
+      .withQueryParam("key", apiKey)
+      .withQueryParam("q", URLEncoder.encode(searchQuery, StandardCharsets.UTF_8))
+      .withQueryParam("type", "video")
+      .withQueryParam("order", "date")
+      .withQueryParam("maxResults", 50)
+      .withQueryParam("part", "snippet")
+
   test("searchVideos should handle multiple pages") {
+    val searchQuery = "test-query"
     implicit val client: Client[IO] = mockClient(
       Map(
-        Uri.unsafeFromString(s"$baseUrl/search?pageToken=page2") -> Response[IO](Status.Ok).withEntity(searchResponsePage2.asJson),
-        Uri.unsafeFromString(s"$baseUrl/search") -> Response[IO](Status.Ok).withEntity(searchResponsePage1.asJson)
+        buildSearchUri(searchQuery).withQueryParam("pageToken", "page2") -> Response[IO](Status.Ok).withEntity(searchResponsePage2.asJson),
+        buildSearchUri(searchQuery) -> Response[IO](Status.Ok).withEntity(searchResponsePage1.asJson)
       )
     )
 
     val fetcher = new YouTubeFetcher[IO](apiKey, baseUrl)
-
-    val result = TestControl.execute {
-      for {
-        videos <- fetcher.searchVideos("test-query")
-        _ <- IO {
-          videos shouldBe Map(
-            "channel1" -> List("video1", "video3"),
-            "channel2" -> List("video2")
-          )
-        }
-      } yield ()
-    }
-
-    result.flatMap(_.tickAll)
+    val videos = fetcher.searchVideos(searchQuery).unsafeRunSync()
+    videos shouldBe Map(
+      "channel1" -> List("video1", "video3"),
+      "channel2" -> List("video2")
+    )
   }
 
   test("filterVideosByChannels should filter videos correctly") {
@@ -95,58 +106,44 @@ class YouTubeFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
     result should contain theSameElementsAs List("video1", "video3", "video2")
   }
 
-  test("fetchVideoDetails should filter videos based on criteria") {
-    implicit val client: Client[IO] = mockClient(
-      Map(
-        Uri.unsafeFromString(s"$baseUrl/videos") -> Response[IO](Status.Ok).withEntity(videoDetailsResponse.asJson)
-      )
-    )
+  test("fetchVideoDetails should filter videos based on video duration and view count") {
+    val videosIds = List("video1", "video2")
+
+    implicit val client: Client[IO] = mockClient(Map(
+      buildVideosDetailsUri(videosIds) -> Response[IO](Status.Ok).withEntity(videoDetailsResponse.asJson)
+    ))
 
     val fetcher = new YouTubeFetcher[IO](apiKey, baseUrl)
+    val details = fetcher.fetchVideoDetails(videosIds, 120, 50).unsafeRunSync()
 
-    val result = TestControl.execute {
-      for {
-        details <- fetcher.fetchVideoDetails(List("video1", "video2"), 120, 100)
-        _ <- IO {
-          details should have size 1
-          details.head.id shouldBe "video1"
-        }
-      } yield ()
-    }
-
-    result.flatMap(_.tickAll)
+    details should have size 1
+    details.head.id shouldBe "video1"
   }
 
   test("fetchVideoUpdates should generate updates for valid users and videos") {
-    implicit val client: Client[IO] = mockClient(
-      Map(
-        Uri.unsafeFromString(s"$baseUrl/videos") -> Response[IO](Status.Ok).withEntity(videoDetailsResponse.asJson)
-      )
-    )
-
-    val fetcher = new YouTubeFetcher[IO](apiKey, baseUrl)
-
     val globalSearchResult = Map(
       "channel1" -> List("video1"),
       "channel2" -> List("video2")
     )
 
-    val result = TestControl.execute {
-      for {
-        updates <- fetcher.fetchVideoUpdates(
-          List(LatticeUser("user1", Some(dagAddress1), Some(YouTubeAccount("channel1")), None)),
-          searchInfo,
-          globalSearchResult
-        )
-        _ <- IO {
-          updates should have size 1
-          updates.head.address shouldBe dagAddress1
-          updates.head.video.id shouldBe "video1"
-        }
-      } yield ()
-    }
+    implicit val client: Client[IO] = mockClient(Map(
+      buildVideosDetailsUri(List("video1", "video2")) -> Response[IO](Status.Ok).withEntity(videoDetailsResponse.asJson)
+    ))
 
-    result.flatMap(_.tickAll)
+    val fetcher = new YouTubeFetcher[IO](apiKey, baseUrl)
+
+    val updates = fetcher.fetchVideoUpdates(
+      List(
+        LatticeUser("user1", Some(dagAddress1), Some(YouTubeAccount("channel1")), None),
+        LatticeUser("user2", Some(dagAddress2), Some(YouTubeAccount("channel2")), None)
+      ),
+      searchInfo,
+      globalSearchResult
+    ).unsafeRunSync()
+
+    updates should have size 2
+    updates.head.address shouldBe dagAddress1
+    updates.head.video.id shouldBe "video1"
   }
 
 }

--- a/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/YouTubeFetcherSuite.scala
+++ b/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/YouTubeFetcherSuite.scala
@@ -165,8 +165,8 @@ class YouTubeFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
     val fetcher = new YouTubeFetcher[IO](apiKey, baseUrl)
     val updates = fetcher.fetchVideoUpdates(
       List(
-        LatticeUser("user1", Some(dagAddress1), LinkedAccounts(Some(YouTubeAccount("channel1")), None)),
-        LatticeUser("user2", Some(dagAddress2), LinkedAccounts(Some(YouTubeAccount("channel2")), None))
+        LatticeUser("user1", Some(dagAddress1), Some(LinkedAccounts(Some(YouTubeAccount("channel1")), None)), None),
+        LatticeUser("user2", Some(dagAddress2), Some(LinkedAccounts(Some(YouTubeAccount("channel2")), None)), None)
       ),
       List("video1", "video2"),
       searchInfo.copy(minimumDuration = 2.minutes)
@@ -191,7 +191,7 @@ class YouTubeFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
     val dataSource = YouTubeDataSource(ListMap(dagAddress1 -> YouTubeDataSourceAddress(ListMap(testQuery -> rewardInfo))))
 
     val latticeUsers = List(
-      LatticeUser("user1", Some(dagAddress1), LinkedAccounts(Some(YouTubeAccount("channel1")), None))
+      LatticeUser("user1", Some(dagAddress1), Some(LinkedAccounts(Some(YouTubeAccount("channel1")), None)), None)
     )
 
     val result = YouTubeFetcher.filterLatticeUsers(
@@ -217,7 +217,7 @@ class YouTubeFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
     val dataSource = YouTubeDataSource(ListMap(dagAddress1 -> YouTubeDataSourceAddress(ListMap(testQuery -> rewardInfo))))
 
     val latticeUsers = List(
-      LatticeUser("user1", Some(dagAddress1), LinkedAccounts(Some(YouTubeAccount("channel1")), None))
+      LatticeUser("user1", Some(dagAddress1), Some(LinkedAccounts(Some(YouTubeAccount("channel1")), None)), None)
     )
 
     val result = YouTubeFetcher.filterLatticeUsers(
@@ -245,7 +245,7 @@ class YouTubeFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
     val dataSource = YouTubeDataSource(ListMap(dagAddress1 -> YouTubeDataSourceAddress(ListMap(testQuery -> rewardInfo))))
 
     val latticeUsers = List(
-      LatticeUser("user1", Some(dagAddress1), LinkedAccounts(Some(YouTubeAccount("channel1")), None))
+      LatticeUser("user1", Some(dagAddress1), Some(LinkedAccounts(Some(YouTubeAccount("channel1")), None)), None)
     )
 
     val result = YouTubeFetcher.filterLatticeUsers(
@@ -272,7 +272,7 @@ class YouTubeFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
     val dataSource = YouTubeDataSource(ListMap(dagAddress1 -> YouTubeDataSourceAddress(ListMap(testQuery -> rewardInfo))))
 
     val latticeUsers = List(
-      LatticeUser("user1", Some(dagAddress1), LinkedAccounts(Some(YouTubeAccount("channel1")), None))
+      LatticeUser("user1", Some(dagAddress1), Some(LinkedAccounts(Some(YouTubeAccount("channel1")), None)), None)
     )
 
     val result = YouTubeFetcher.filterLatticeUsers(
@@ -322,9 +322,9 @@ class YouTubeFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
     )
 
     val latticeUsers = List(
-      LatticeUser("user1", Some(dagAddress1), LinkedAccounts(Some(YouTubeAccount("channel1")), None)),
-      LatticeUser("user2", Some(dagAddress2), LinkedAccounts(Some(YouTubeAccount("channel2")), None)),
-      LatticeUser("user3", Some(dagAddress3), LinkedAccounts(Some(YouTubeAccount("channel3")), None))
+      LatticeUser("user1", Some(dagAddress1), Some(LinkedAccounts(Some(YouTubeAccount("channel1")), None)), None),
+      LatticeUser("user2", Some(dagAddress2), Some(LinkedAccounts(Some(YouTubeAccount("channel2")), None)), None),
+      LatticeUser("user3", Some(dagAddress3), Some(LinkedAccounts(Some(YouTubeAccount("channel3")), None)), None)
     )
 
     val result = YouTubeFetcher.filterLatticeUsers(

--- a/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/YouTubeFetcherSuite.scala
+++ b/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/YouTubeFetcherSuite.scala
@@ -2,13 +2,10 @@ package org.elpaca_metagraph.shared_data.daemons.fetcher
 
 import cats.effect._
 import cats.effect.testkit.TestControl
-import cats.syntax.all._
-import eu.timepit.refined.auto._
 import io.circe.syntax._
 import org.elpaca_metagraph.shared_data.Utils.toTokenAmountFormat
 import org.elpaca_metagraph.shared_data.app.ApplicationConfig
-import org.elpaca_metagraph.shared_data.types.Refined.ApiUrl
-import org.elpaca_metagraph.shared_data.types.YouTube.LatticeClient._
+import org.elpaca_metagraph.shared_data.types.Lattice._
 import org.elpaca_metagraph.shared_data.types.YouTube.YouTubeDataAPI._
 import org.http4s._
 import org.http4s.circe._
@@ -16,31 +13,12 @@ import org.http4s.client.Client
 import org.http4s.implicits._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import org.tessellation.schema.address.Address
-import org.typelevel.log4cats.SelfAwareStructuredLogger
-import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import java.time.Instant
-import scala.concurrent.duration._
 
-class YouTubeFetcherSuite extends AnyFunSuite with Matchers {
-  implicit val logger: SelfAwareStructuredLogger[IO] = Slf4jLogger.getLoggerFromClass(this.getClass)
-
+class YouTubeFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
   private val apiKey = "mockApiKey"
-  private val baseUrl = ApiUrl.unsafeFrom("http://localhost:8080")
   private val searchInfo = ApplicationConfig.YouTubeSearchInfo("test-query", toTokenAmountFormat(50), 60, 50, 1, 24)
-
-  private val dagAddress1 = Address("DAG56BtU1j5uCMb5f1QxZ5oxfBhpUeYucRGygfEa")
-  private val dagAddress2 = Address("DAG45ZLcgmQeRHY3oV2ZJACrFUjEZwqeXKSfZc75")
-
-  private val latticeUsersResponse = LatticeUsersApiResponse(
-    data = List(
-      LatticeUser("user1", Some(dagAddress1), Some(YouTubeAccount("channel1"))),
-      LatticeUser("user2", None, Some(YouTubeAccount("channel2"))),
-      LatticeUser("user3", Some(dagAddress2), None)
-    ),
-    meta = Some(LatticeUserMeta(total = 3, limit = 100, offset = 0))
-  )
 
   private val searchResponsePage1 = SearchListResponse(
     items = List(
@@ -61,42 +39,28 @@ class YouTubeFetcherSuite extends AnyFunSuite with Matchers {
 
   private val videoDetailsResponse = VideoListResponse(
     items = List(
-      VideoResponse("video1", VideoSnippetResponse("channel1", Instant.now()), VideoStatisticsResponse(Some(500)), VideoContentDetailsResponse("PT3M")),
-      VideoResponse("video2", VideoSnippetResponse("channel2", Instant.now()), VideoStatisticsResponse(Some(50)), VideoContentDetailsResponse("PT2M"))
+      VideoResponse(
+        "video1",
+        VideoSnippetResponse("channel1", Instant.now()),
+        VideoStatisticsResponse(Some(500)),
+        VideoContentDetailsResponse("PT3M")
+      ),
+      VideoResponse(
+        "video2",
+        VideoSnippetResponse("channel2", Instant.now()),
+        VideoStatisticsResponse(Some(50)),
+        VideoContentDetailsResponse("PT2M")
+      )
     )
   )
 
-  def mockClient(responses: Map[Uri, Response[IO]]): Client[IO] = Client.fromHttpApp(HttpRoutes.of[IO] {
-    case req if responses.contains(req.uri) =>
-      responses(req.uri).pure[IO]
-  }.orNotFound)
-
-  test("fetchLatticeUsers should return only valid users") {
-    implicit val client: Client[IO] = mockClient(Map(
-      Uri.unsafeFromString(baseUrl.toString()) -> Response[IO](Status.Ok).withEntity(latticeUsersResponse.asJson)
-    ))
-
-    val fetcher = new YouTubeFetcher[IO](apiKey, baseUrl)
-
-    val result = TestControl.execute {
-      for {
-        users <- fetcher.fetchLatticeUsers(baseUrl)
-        _ <- IO {
-          users should have size 1
-          users.head.primaryDagAddress shouldBe Some(dagAddress1)
-          users.head.youtube.map(_.channelId) shouldBe Some("channel1")
-        }
-      } yield ()
-    }
-
-    result.flatMap(_.tickAll)
-  }
-
   test("searchVideos should handle multiple pages") {
-    implicit val client: Client[IO] = mockClient(Map(
-      Uri.unsafeFromString(s"$baseUrl/search?pageToken=page2") -> Response[IO](Status.Ok).withEntity(searchResponsePage2.asJson),
-      Uri.unsafeFromString(s"$baseUrl/search") -> Response[IO](Status.Ok).withEntity(searchResponsePage1.asJson)
-    ))
+    implicit val client: Client[IO] = mockClient(
+      Map(
+        Uri.unsafeFromString(s"$baseUrl/search?pageToken=page2") -> Response[IO](Status.Ok).withEntity(searchResponsePage2.asJson),
+        Uri.unsafeFromString(s"$baseUrl/search") -> Response[IO](Status.Ok).withEntity(searchResponsePage1.asJson)
+      )
+    )
 
     val fetcher = new YouTubeFetcher[IO](apiKey, baseUrl)
 
@@ -132,9 +96,11 @@ class YouTubeFetcherSuite extends AnyFunSuite with Matchers {
   }
 
   test("fetchVideoDetails should filter videos based on criteria") {
-    implicit val client: Client[IO] = mockClient(Map(
-      Uri.unsafeFromString(s"$baseUrl/videos") -> Response[IO](Status.Ok).withEntity(videoDetailsResponse.asJson)
-    ))
+    implicit val client: Client[IO] = mockClient(
+      Map(
+        Uri.unsafeFromString(s"$baseUrl/videos") -> Response[IO](Status.Ok).withEntity(videoDetailsResponse.asJson)
+      )
+    )
 
     val fetcher = new YouTubeFetcher[IO](apiKey, baseUrl)
 
@@ -152,9 +118,11 @@ class YouTubeFetcherSuite extends AnyFunSuite with Matchers {
   }
 
   test("fetchVideoUpdates should generate updates for valid users and videos") {
-    implicit val client: Client[IO] = mockClient(Map(
-      Uri.unsafeFromString(s"$baseUrl/videos") -> Response[IO](Status.Ok).withEntity(videoDetailsResponse.asJson)
-    ))
+    implicit val client: Client[IO] = mockClient(
+      Map(
+        Uri.unsafeFromString(s"$baseUrl/videos") -> Response[IO](Status.Ok).withEntity(videoDetailsResponse.asJson)
+      )
+    )
 
     val fetcher = new YouTubeFetcher[IO](apiKey, baseUrl)
 
@@ -166,7 +134,7 @@ class YouTubeFetcherSuite extends AnyFunSuite with Matchers {
     val result = TestControl.execute {
       for {
         updates <- fetcher.fetchVideoUpdates(
-          List(LatticeUser("user1", Some(dagAddress1), Some(YouTubeAccount("channel1")))),
+          List(LatticeUser("user1", Some(dagAddress1), Some(YouTubeAccount("channel1")), None)),
           searchInfo,
           globalSearchResult
         )
@@ -176,115 +144,6 @@ class YouTubeFetcherSuite extends AnyFunSuite with Matchers {
           updates.head.video.id shouldBe "video1"
         }
       } yield ()
-    }
-
-    result.flatMap(_.tickAll)
-  }
-
-  test("fetchLatticeUsers should handle API errors gracefully") {
-    implicit val client: Client[IO] = mockClient(Map(
-      Uri.unsafeFromString(baseUrl.toString()) -> Response[IO](Status.InternalServerError)
-    ))
-
-    val fetcher = new YouTubeFetcher[IO](apiKey, baseUrl)
-
-    val result = TestControl.execute {
-      fetcher.fetchLatticeUsers(baseUrl).attempt.map {
-        case Left(error) => error shouldBe a[Throwable]
-        case Right(_)    => fail("Expected an error but got success")
-      }
-    }
-
-    result.flatMap(_.tickAll)
-  }
-
-  test("fetchLatticeUsers should handle large datasets") {
-    val largeResponse = LatticeUsersApiResponse(
-      data = List.fill(1000)(LatticeUser("user", Some(dagAddress1), Some(YouTubeAccount("channel1")))),
-      meta = Some(LatticeUserMeta(total = 1000, limit = 100, offset = 0))
-    )
-
-    implicit val client: Client[IO] = mockClient(Map(
-      Uri.unsafeFromString(baseUrl.toString()) -> Response[IO](Status.Ok).withEntity(largeResponse.asJson)
-    ))
-
-    val fetcher = new YouTubeFetcher[IO](apiKey, baseUrl)
-
-    val result = TestControl.execute {
-      fetcher.fetchLatticeUsers(baseUrl).map { users =>
-        users should have size 1000
-      }
-    }
-
-    result.flatMap(_.tickAll)
-  }
-
-  test("YouTubeFetcher should fail with invalid API key") {
-    implicit val mockClient: Client[IO] = Client.fromHttpApp(HttpRoutes.empty[IO].orNotFound)
-    val invalidApiKey = ""
-    val fetcher = new YouTubeFetcher[IO](invalidApiKey, baseUrl)
-
-    val result = TestControl.execute {
-      fetcher.fetchLatticeUsers(baseUrl).attempt.map {
-        case Left(error) => error shouldBe a[Throwable]
-        case Right(_)    => fail("Expected an error but got success")
-      }
-    }
-
-    result.flatMap(_.tickAll)
-  }
-
-  test("YouTubeFetcher should handle rate-limiting gracefully") {
-    val rateLimitResponse = Response[IO](Status.TooManyRequests)
-
-    implicit val client: Client[IO] = mockClient(Map(
-      Uri.unsafeFromString(baseUrl.toString()) -> rateLimitResponse
-    ))
-
-    val fetcher = new YouTubeFetcher[IO](apiKey, baseUrl)
-
-    val result = TestControl.execute {
-      fetcher.fetchLatticeUsers(baseUrl).attempt.map {
-        case Left(error) => error shouldBe a[Throwable]
-        case Right(_)    => fail("Expected an error but got success")
-      }
-    }
-
-    result.flatMap(_.tickAll)
-  }
-
-  test("YouTubeFetcher should log API responses and errors") {
-    val response = Response[IO](Status.Ok).withEntity(latticeUsersResponse.asJson)
-
-    implicit val client: Client[IO] = mockClient(Map(
-      Uri.unsafeFromString(baseUrl.toString()) -> response
-    ))
-
-    val fetcher = new YouTubeFetcher[IO](apiKey, baseUrl)
-
-    val result = TestControl.execute {
-      fetcher.fetchLatticeUsers(baseUrl).flatMap { _ =>
-        logger.info("API responded successfully")
-      }
-    }
-
-    result.flatMap(_.tickAll)
-  }
-
-  test("YouTubeFetcher should handle API timeouts") {
-    val delayedResponse = IO.sleep(5.seconds) *> Response[IO](Status.Ok).withEntity(latticeUsersResponse.asJson).pure[IO]
-
-    implicit val client: Client[IO] = Client.fromHttpApp(HttpRoutes.of[IO] {
-      case _ => delayedResponse
-    }.orNotFound)
-
-    val fetcher = new YouTubeFetcher[IO](apiKey, baseUrl)
-
-    val result = TestControl.execute {
-      fetcher.fetchLatticeUsers(baseUrl).attempt.map {
-        case Left(error) => error shouldBe a[Throwable]
-        case Right(_)    => fail("Expected an error but got success")
-      }
     }
 
     result.flatMap(_.tickAll)

--- a/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/YouTubeFetcherSuite.scala
+++ b/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/YouTubeFetcherSuite.scala
@@ -2,25 +2,38 @@ package org.elpaca_metagraph.shared_data.daemons.fetcher
 
 import cats.effect._
 import cats.effect.unsafe.implicits.global
+import eu.timepit.refined.types.numeric.NonNegLong
 import io.circe.syntax._
 import org.elpaca_metagraph.shared_data.Utils.toTokenAmountFormat
-import org.elpaca_metagraph.shared_data.app.ApplicationConfig
+import org.elpaca_metagraph.shared_data.app.ApplicationConfig.YouTubeSearchInfo
 import org.elpaca_metagraph.shared_data.types.Lattice._
+import org.elpaca_metagraph.shared_data.types.States.YouTubeDataSource
 import org.elpaca_metagraph.shared_data.types.YouTube.YouTubeDataAPI._
+import org.elpaca_metagraph.shared_data.types.YouTube._
 import org.http4s._
 import org.http4s.circe._
 import org.http4s.client.Client
 import org.http4s.implicits._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import org.tessellation.schema.epoch.EpochProgress
 
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.time.Instant
+import scala.collection.immutable.ListMap
 
 class YouTubeFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
   private val apiKey = "mockApiKey"
-  private val searchInfo = ApplicationConfig.YouTubeSearchInfo("test-query", toTokenAmountFormat(50), 60, 50, 1, 24)
+  private val testQuery = "test-query"
+  private val searchInfo = YouTubeSearchInfo(
+    text = testQuery,
+    rewardAmount = toTokenAmountFormat(50),
+    maxPerDay = 1,
+    minimumDuration = 60,
+    minimumViews = 50,
+    publishedWithinHours = 3
+  )
 
   private val searchResponsePage1 = SearchListResponse(
     items = List(
@@ -28,7 +41,7 @@ class YouTubeFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
       VideoSummary(Id("video2"), VideoSnippetResponse("channel2", Instant.now()))
     ),
     pageInfo = PageInfo(2),
-    nextPageToken = Some("page2")
+    nextPageToken = None
   )
 
   private val searchResponsePage2 = SearchListResponse(
@@ -73,17 +86,39 @@ class YouTubeFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
       .withQueryParam("maxResults", 50)
       .withQueryParam("part", "snippet")
 
-  test("searchVideos should handle multiple pages") {
-    val searchQuery = "test-query"
+  test("searchVideos should return relevant videos for the provided search term") {
+    implicit val client: Client[IO] = mockClient(Map(
+      buildSearchUri(testQuery) -> Response[IO](Status.Ok).withEntity(searchResponsePage1.asJson)
+    ))
+
+    val fetcher = new YouTubeFetcher[IO](apiKey, baseUrl)
+    val videos = fetcher.searchVideos(testQuery).unsafeRunSync()
+    videos shouldBe Map("channel1" -> List("video1"), "channel2" -> List("video2"))
+  }
+
+  test("searchVideos handling a single result") {
+    implicit val client: Client[IO] = mockClient(Map(
+      buildSearchUri(testQuery) -> Response[IO](Status.Ok).withEntity(searchResponsePage2.asJson)
+    ))
+
+    val fetcher = new YouTubeFetcher[IO](apiKey, baseUrl)
+    val videos = fetcher.searchVideos(testQuery).unsafeRunSync()
+    videos shouldBe Map("channel1" -> List("video3"))
+  }
+
+  test("searchVideos should handle multiple pages, correctly grouping results by channel") {
     implicit val client: Client[IO] = mockClient(
       Map(
-        buildSearchUri(searchQuery).withQueryParam("pageToken", "page2") -> Response[IO](Status.Ok).withEntity(searchResponsePage2.asJson),
-        buildSearchUri(searchQuery) -> Response[IO](Status.Ok).withEntity(searchResponsePage1.asJson)
+        buildSearchUri(testQuery)
+          -> Response[IO](Status.Ok).withEntity(searchResponsePage1.copy(pageInfo = PageInfo(3), nextPageToken = Some("page2")).asJson),
+
+        buildSearchUri(testQuery).withQueryParam("pageToken", "page2")
+          -> Response[IO](Status.Ok).withEntity(searchResponsePage2.copy(pageInfo = PageInfo(3)).asJson)
       )
     )
 
     val fetcher = new YouTubeFetcher[IO](apiKey, baseUrl)
-    val videos = fetcher.searchVideos(searchQuery).unsafeRunSync()
+    val videos = fetcher.searchVideos(testQuery).unsafeRunSync()
     videos shouldBe Map(
       "channel1" -> List("video1", "video3"),
       "channel2" -> List("video2")
@@ -92,16 +127,14 @@ class YouTubeFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
 
   test("filterVideosByChannels should filter videos correctly") {
     implicit val mockClient: Client[IO] = Client.fromHttpApp(HttpRoutes.empty[IO].orNotFound)
-
     val fetcher = new YouTubeFetcher[IO](apiKey, baseUrl)
-    val channelVideoMap = Map(
+    val videos = Map(
       "channel1" -> List("video1", "video3"),
       "channel2" -> List("video2"),
-      "channel3" -> List("video4")
+      "channel3" -> List("video4") // no lattice user for channel3 - should be skipped
     )
-    val allowedChannels = List("channel1", "channel2")
-
-    val result = fetcher.filterVideosByChannels(channelVideoMap, allowedChannels)
+    val channelsFromValidLatticeUsers = List("channel1", "channel2")
+    val result = fetcher.filterVideosByChannels(videos, channelsFromValidLatticeUsers)
 
     result should contain theSameElementsAs List("video1", "video3", "video2")
   }
@@ -131,7 +164,6 @@ class YouTubeFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
     ))
 
     val fetcher = new YouTubeFetcher[IO](apiKey, baseUrl)
-
     val updates = fetcher.fetchVideoUpdates(
       List(
         LatticeUser("user1", Some(dagAddress1), LinkedAccounts(Some(YouTubeAccount("channel1")), None)),
@@ -141,9 +173,169 @@ class YouTubeFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
       globalSearchResult
     ).unsafeRunSync()
 
-    updates should have size 2
+    updates should have size 1 // video 2 doesn't meet the minimum views requirement
     updates.head.address shouldBe dagAddress1
     updates.head.video.id shouldBe "video1"
+  }
+
+  test("filterLatticeUsers should exclude users with videos already rewarded") {
+    val rewardedVideo = Some(VideoDetails("video1", "channel1", Instant.now(), 1000, 180))
+    val rewardInfo = YouTubeRewardInfo(
+      EpochProgress(NonNegLong(1)),
+      EpochProgress(NonNegLong(1)),
+      toTokenAmountFormat(50),
+      testQuery,
+      List(rewardedVideo.get),
+      1
+    )
+    val dataSource = YouTubeDataSource(ListMap(dagAddress1 -> YouTubeDataSourceAddress(ListMap(testQuery -> rewardInfo))))
+
+    val latticeUsers = List(
+      LatticeUser("user1", Some(dagAddress1), LinkedAccounts(Some(YouTubeAccount("channel1")), None))
+    )
+
+    val result = YouTubeFetcher.filterLatticeUsers(
+      latticeUsers,
+      List(searchInfo),
+      dataSource,
+      rewardedVideo
+    )
+
+    result shouldBe empty
+  }
+
+  test("filterLatticeUsers should include users with videos not yet rewarded and under daily limit") {
+    val unrewardedVideo = VideoDetails("video2", "channel1", Instant.now(), 900, 120)
+    val rewardInfo = YouTubeRewardInfo(
+      EpochProgress(NonNegLong(0)),
+      EpochProgress(NonNegLong(1)),
+      toTokenAmountFormat(50),
+      testQuery,
+      List.empty,
+      0
+    )
+    val dataSource = YouTubeDataSource(ListMap(dagAddress1 -> YouTubeDataSourceAddress(ListMap(testQuery -> rewardInfo))))
+
+    val latticeUsers = List(
+      LatticeUser("user1", Some(dagAddress1), LinkedAccounts(Some(YouTubeAccount("channel1")), None))
+    )
+
+    val result = YouTubeFetcher.filterLatticeUsers(
+      latticeUsers,
+      List(searchInfo),
+      dataSource,
+      Some(unrewardedVideo)
+    )
+
+    result should have size 1
+    result.head.primaryDagAddress shouldBe Some(dagAddress1)
+  }
+
+  test("filterLatticeUsers should exclude users exceeding daily limit of one reward") {
+    val unrewardedVideo = VideoDetails("video2", "channel1", Instant.now(), 900, 120)
+    val rewardInfo = YouTubeRewardInfo(
+      EpochProgress(NonNegLong(1)),
+      EpochProgress(NonNegLong(1)),
+      toTokenAmountFormat(50),
+      testQuery,
+      List(unrewardedVideo),
+      1
+    )
+
+    val dataSource = YouTubeDataSource(ListMap(dagAddress1 -> YouTubeDataSourceAddress(ListMap(testQuery -> rewardInfo))))
+
+    val latticeUsers = List(
+      LatticeUser("user1", Some(dagAddress1), LinkedAccounts(Some(YouTubeAccount("channel1")), None))
+    )
+
+    val result = YouTubeFetcher.filterLatticeUsers(
+      latticeUsers,
+      List(searchInfo),
+      dataSource,
+      Some(unrewardedVideo)
+    )
+
+    result shouldBe empty
+  }
+
+  test("filterLatticeUsers should not reward twice the same video") {
+    val rewardedVideo = VideoDetails("video2", "channel1", Instant.now(), 900, 120)
+    val rewardInfo = YouTubeRewardInfo(
+      EpochProgress(NonNegLong(1)),
+      EpochProgress(NonNegLong(1)),
+      toTokenAmountFormat(50),
+      testQuery,
+      List(rewardedVideo),
+      0
+    )
+
+    val dataSource = YouTubeDataSource(ListMap(dagAddress1 -> YouTubeDataSourceAddress(ListMap(testQuery -> rewardInfo))))
+
+    val latticeUsers = List(
+      LatticeUser("user1", Some(dagAddress1), LinkedAccounts(Some(YouTubeAccount("channel1")), None))
+    )
+
+    val result = YouTubeFetcher.filterLatticeUsers(
+      latticeUsers,
+      List(searchInfo),
+      dataSource,
+      Some(rewardedVideo)
+    )
+
+    result shouldBe empty
+  }
+
+  test("filterLatticeUsers should handle multiple users with mixed daily limits") {
+    val dataSource = YouTubeDataSource(
+      ListMap(
+        dagAddress1 -> YouTubeDataSourceAddress(
+          ListMap(testQuery -> YouTubeRewardInfo(
+            EpochProgress(NonNegLong(1)),
+            EpochProgress(NonNegLong(1)),
+            toTokenAmountFormat(50),
+            testQuery,
+            List(VideoDetails("video1", "channel1", Instant.now(), 1000, 180)),
+            1 // Daily limit reached
+          ))
+        ),
+        dagAddress2 -> YouTubeDataSourceAddress(
+          ListMap(testQuery -> YouTubeRewardInfo(
+            EpochProgress(NonNegLong(0)),
+            EpochProgress(NonNegLong(1)),
+            toTokenAmountFormat(50),
+            testQuery,
+            List(VideoDetails("video2", "channel2", Instant.now(), 1000, 180)),
+            0 // No rewards yet
+          ))
+        ),
+        dagAddress3 -> YouTubeDataSourceAddress(
+          ListMap(testQuery -> YouTubeRewardInfo(
+            EpochProgress(NonNegLong(1)),
+            EpochProgress(NonNegLong(1)),
+            toTokenAmountFormat(50),
+            testQuery,
+            List(VideoDetails("video3", "channel3", Instant.now(), 1000, 180)),
+            1 // Daily limit reached
+          ))
+        )
+      )
+    )
+
+    val latticeUsers = List(
+      LatticeUser("user1", Some(dagAddress1), LinkedAccounts(Some(YouTubeAccount("channel1")), None)),
+      LatticeUser("user2", Some(dagAddress2), LinkedAccounts(Some(YouTubeAccount("channel2")), None)),
+      LatticeUser("user3", Some(dagAddress3), LinkedAccounts(Some(YouTubeAccount("channel3")), None))
+    )
+
+    val result = YouTubeFetcher.filterLatticeUsers(
+      latticeUsers,
+      List(searchInfo),
+      dataSource,
+      None
+    )
+
+    result should have size 1
+    result.head.primaryDagAddress shouldBe Some(dagAddress2)
   }
 
 }

--- a/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/YouTubeFetcherSuite.scala
+++ b/modules/shared_data/src/test/scala/org/elpaca_metagraph/shared_data/daemons/fetcher/YouTubeFetcherSuite.scala
@@ -134,8 +134,8 @@ class YouTubeFetcherSuite extends AnyFunSuite with Matchers with FetcherSuite {
 
     val updates = fetcher.fetchVideoUpdates(
       List(
-        LatticeUser("user1", Some(dagAddress1), Some(YouTubeAccount("channel1")), None),
-        LatticeUser("user2", Some(dagAddress2), Some(YouTubeAccount("channel2")), None)
+        LatticeUser("user1", Some(dagAddress1), LinkedAccounts(Some(YouTubeAccount("channel1")), None)),
+        LatticeUser("user2", Some(dagAddress2), LinkedAccounts(Some(YouTubeAccount("channel2")), None))
       ),
       searchInfo,
       globalSearchResult


### PR DESCRIPTION
Created abstraction for pulling out lattice users and refactored XFetcher and YouTubeFetcher to use the new LatticeFetcher abstraction.

This update allows easier unit testing and separate responsibilities from X and YouTube datasources.